### PR TITLE
Fixing roxygen documentation for ml_model r6 class

### DIFF
--- a/R/ml_model.R
+++ b/R/ml_model.R
@@ -1,6 +1,5 @@
-##' R6 class for prediction models
-##'
-##' Provides standardized estimation and prediction methods
+##' @title R6 class for prediction models
+##' @description Provides standardized estimation and prediction methods
 ##' @author Klaus Kähler Holst
 ##' @examples
 ##' data(iris)

--- a/man/ml_model.Rd
+++ b/man/ml_model.Rd
@@ -4,11 +4,6 @@
 \alias{ml_model}
 \title{R6 class for prediction models}
 \description{
-R6 class for prediction models
-
-R6 class for prediction models
-}
-\details{
 Provides standardized estimation and prediction methods
 }
 \examples{


### PR DESCRIPTION
Incorrect roxygen documentation for ml_model R6 class (see also https://www.rdocumentation.org/packages/targeted/versions/0.3/topics/ml_model)

Expected `?ml_model`: 
```
R6 class for prediction models

Description:

     Provides standardized estimation and prediction methods
```
Actual:

```
Description:

     R6 class for prediction models

     R6 class for prediction models
```