### PR TITLE
develop: fix install rules in Makefile + fix pdf documentation of RATE.surv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PKG ?= targeted
 R = R --silent --no-save --no-echo
 BUILD_DIR = build
 GETVER = $(shell cat DESCRIPTION | grep Version | cut -d":" -f2 | tr -d '[:blank:]')
+make_build_dir = rm -Rf $(BUILD_DIR) && mkdir -p $(BUILD_DIR)
 
 default: check
 
@@ -25,17 +26,17 @@ clean:
 
 .PHONY: build
 build:
-	@rm -Rf $(BUILD_DIR) && mkdir -p $(BUILD_DIR)
+	@$(make_build_dir)
 	@echo 'pkgbuild::build(path=".", dest_path="$(BUILD_DIR)", args="--compact-vignettes=qpdf --resave-data=best")' | $(R)
 
 install:
-	@echo 'devtools::install("$(pkg)", upgrade = "never")' | $(R)
+	@echo 'devtools::install(".", upgrade = "never")' | $(R)
 
 dependencies-install:
-	@echo 'devtools::install_deps("$(pkg)", dependencies = TRUE)' | $(R)
+	@echo 'devtools::install_deps(".", dependencies = TRUE)' | $(R)
 
 dependencies-upgrade:
-	@echo 'devtools::install("$(pkg)", upgrade = "always")' | $(R)
+	@echo 'devtools::install(".", upgrade = "always")' | $(R)
 
 check-cran: build
 	@$(R) CMD check build/$(PKG)_$(GETVER).tar.gz --timings --as-cran --no-multiarch --run-donttest
@@ -56,3 +57,9 @@ test-loadall:
 coverage:
 	@echo 'covr::report(file="tests/coverage-report.html")' | $(R)
 	@open tests/coverage-report.html
+
+.PHONY: man
+man:
+	@$(make_build_dir)
+	@echo 'devtools::build_manual(".", path = "$(BUILD_DIR)")' | $(R)
+	@open build/$(PKG)_$(GETVER).pdf

--- a/R/RATE.R
+++ b/R/RATE.R
@@ -139,7 +139,9 @@ RATE <- function(response, post.treatment, treatment,
 #' An efficient one-step estimator of \eqn{P(T \leq \tau|A=a)} is constructed using
 #' the efficient influence function
 #' \deqn{
-#' \frac{I\{A=a\}}{P(A = a)} \Big(\frac{\Delta}{S^c_{0}(\tilde T|X)} I\{\tilde T \leq \tau\} + \int_0^\tau \frac{S_0(u|X)-S_0(\tau|X)}{S_0(u|X)S^c_0(u|X)} d M^c_0(u|X))\Big)\\
+#' \frac{I\{A=a\}}{P(A = a)} \Big(\frac{\Delta}{S^c_{0}(\tilde T|X)} I\{\tilde T \leq \tau\} + \int_0^\tau \frac{S_0(u|X)-S_0(\tau|X)}{S_0(u|X)S^c_0(u|X)} d M^c_0(u|X)\Big)
+#' }
+#' \deqn{
 #' + \Big(1 - \frac{I\{A=a\}}{P(A = a)}\Big)F_0(\tau|A=a, W) - P(T \leq \tau|A=a).
 #' }
 #' An efficient one-step estimator of \eqn{E[D|A=1]} is constructed using the efficient influence function

--- a/man/RATE.surv.Rd
+++ b/man/RATE.surv.Rd
@@ -69,7 +69,9 @@ under right censoring based on plug-in estimates of \eqn{P(T \leq \tau|A=a)} and
 An efficient one-step estimator of \eqn{P(T \leq \tau|A=a)} is constructed using
 the efficient influence function
 \deqn{
-\frac{I\{A=a\}}{P(A = a)} \Big(\frac{\Delta}{S^c_{0}(\tilde T|X)} I\{\tilde T \leq \tau\} + \int_0^\tau \frac{S_0(u|X)-S_0(\tau|X)}{S_0(u|X)S^c_0(u|X)} d M^c_0(u|X))\Big)\\
+\frac{I\{A=a\}}{P(A = a)} \Big(\frac{\Delta}{S^c_{0}(\tilde T|X)} I\{\tilde T \leq \tau\} + \int_0^\tau \frac{S_0(u|X)-S_0(\tau|X)}{S_0(u|X)S^c_0(u|X)} d M^c_0(u|X)\Big)
+}
+\deqn{
 + \Big(1 - \frac{I\{A=a\}}{P(A = a)}\Big)F_0(\tau|A=a, W) - P(T \leq \tau|A=a).
 }
 An efficient one-step estimator of \eqn{E[D|A=1]} is constructed using the efficient influence function

--- a/man/ate.Rd
+++ b/man/ate.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/ate.R
 \name{ate}
 \alias{ate}
-\title{AIPW (doubly-robust) estimator for Average Treatement Effect}
+\title{AIPW (doubly-robust) estimator for Average Treatment Effect}
 \usage{
 ate(
   formula,
@@ -50,7 +50,7 @@ Augmented Inverse Probability Weighting estimator for the Average (Causal)
 Treatment Effect. All nuisance models are here parametric (glm). For a more
 general approach see the \code{cate} implementation. In this implementation
 the standard errors are correct even when the nuisance models are
-misspecified (the influence curve is calculated including the term coming
+mis-specified (the influence curve is calculated including the term coming
 from the parametric nuisance models). The estimate is consistent if either
 the propensity model or the outcome model / Q-model is correctly specified.
 }

--- a/man/calibration.Rd
+++ b/man/calibration.Rd
@@ -70,7 +70,7 @@ c1 <- calibration(p1, d0$y, breaks=100)
 if (interactive()) {
   plot(c1)
   plot(c2,col="red",add=TRUE)
-  abline(a=0,b=1)##'
+  abline(a=0,b=1)#'
   with(c1$xy[[1]], points(pred,freq,type="b", col="red"))
 }
 
@@ -83,7 +83,7 @@ cal <- calibration(p1, dd[[2]]$y)
 p2 <- predict(mod, newdata=dd[[3]])
 pp <- predict(c1, p2)
 cc <- calibration(pp, dd[[3]]$y)
-if (interactive()) {##'
+if (interactive()) {#'
   plot(cal)
   plot(cc, add=TRUE, col="blue")
 }

--- a/man/riskreg_cens.Rd
+++ b/man/riskreg_cens.Rd
@@ -78,7 +78,7 @@ latter term can be computational intensive to calculate. Rather than
 calculating this integral in all observed time points, we can make a
 coarser evaluation which can be controlled by setting
 \code{control=(sample=N)}. With \code{N=0} the (computational intensive)
-standard evaluation is used.##'
+standard evaluation is used.#'
 }
 \author{
 Klaus K. Holst, Andreas Nordland

--- a/man/specify_ode.Rd
+++ b/man/specify_ode.Rd
@@ -48,7 +48,7 @@ As an example of model with exogenous inputs consider the following ODE:
 This could be specified as
 \code{mod <- 'double t = x(0);
               dy = p(0) + p(1)*y + p(2)*x(1)*y + p(3)*x(1)*t;'}
-\code{dy <- specify_ode(mod)}##'
+\code{dy <- specify_ode(mod)}#'
 }
 \seealso{
 solve_ode


### PR DESCRIPTION
This is a quick and dirty way to split the long equation over two lines. The reference manual looks like this: 

![image](https://github.com/user-attachments/assets/d4eb07a2-6451-46d8-8ab9-4e89eec6c383)

Doing this smarter in roxygen seems to require mathjax: https://stackoverflow.com/questions/71167883/r-help-pages-with-multiline-latex-equations

Also add .rd files that I forgot in one of the previous PRs.