### PR TITLE
feature(ml_model): allow argument updates for estimate and predict methods 

### DIFF
--- a/R/ml_model.R
+++ b/R/ml_model.R
@@ -96,7 +96,6 @@ ml_model <- R6::R6Class("ml_model", # nolint
         dots$fit <- NULL
       }
       estimate <- add_dots(estimate)
-
       des.args <- list(specials = specials)
       fit_formula <- "formula" %in% formalArgs(estimate)
       fit_response_arg <- response.arg %in% formalArgs(estimate)
@@ -112,19 +111,19 @@ ml_model <- R6::R6Class("ml_model", # nolint
       }
       if (no_formula) {
         private$fitfun <- function(...) {
-          args <- c(list(...), dots)
+          args <- update_args(self$args, ...)
           do.call(private$init.estimate, args)
         }
         private$predfun <- function(...) {
-          args <- c(list(...), predict.args)
+          args <- update_args(predict.args, ...)
           do.call(private$init.predict, args)
         }
       } else {
         if (fit_formula) { # Formula in arguments of estimation procedure
           private$fitfun <- function(data, ...) {
+            args <- update_args(self$args, ...)
             args <- c(
-              self$args, list(formula = self$formula, data = data),
-              list(...)
+              args, list(formula = self$formula, data = data)
             )
             return(do.call(private$init.estimate, args))
           }
@@ -135,7 +134,8 @@ ml_model <- R6::R6Class("ml_model", # nolint
               targeted::design,
               c(list(formula = self$formula, data = data), des.args)
             )
-            args <- c(list(xx$x), list(...), self$args)
+            args <- update_args(self$args, ...)
+            args <- c(list(xx$x), args)
             if (fit_x_arg) {
               names(args)[1] <- x.arg
             } else {
@@ -154,16 +154,20 @@ ml_model <- R6::R6Class("ml_model", # nolint
         }
         private$predfun <- function(object, data, ...) {
           if (fit_formula || no_formula) {
-            args <- c(list(object, newdata = data), predict.args, list(...))
+            predict_args_call <- update_args(predict.args, ...)
+            args <- c(list(object, newdata = data), predict_args_call)
           } else {
             args <- list(...)
             des <- update(attr(object, "design"), data)
             for (s in des$specials) {
               if (is.null(args[[s]])) args[[s]] <- des[[s]]
             }
+            predict_args_call <- predict.args
+            predict_args_call[names(args)] <- args
+
             args <- c(list(object,
               newdata = model.matrix(des)
-            ), predict.args, args)
+            ), predict_args_call)
           }
           return(do.call(private$init.predict, args))
         }
@@ -357,4 +361,19 @@ estimate.ml_model <- function(x, ...) {
 #' @export
 predict.ml_model <- function(object, ...) {
   object$predict(...)
+}
+
+#' Utility to update list of arguments with ellipsis
+#' @param args list or NULL
+update_args <- function(args, ...) {
+  if (is.null(args)) args <- list() # because predict.args = NULL by default
+  dots <- list(...)
+
+  # update args for unnamed list of arguments
+  if (length(dots) > 0 && is.null(names(dots))) {
+    args <- dots
+  } else {
+    args[names(dots)] <- dots
+  }
+  return(args)
 }

--- a/R/ml_model.R
+++ b/R/ml_model.R
@@ -74,7 +74,7 @@ ml_model <- R6::R6Class("ml_model", # nolint
     #' @param info optional description of the model
     #' @param predict.args optional arguments to prediction function
     #' @param specials optional additional terms (weights, offset,
-    #'  id, subset, ...) passed to [targeted::design] via the special argument
+    #'  id, subset, ...) passed to 'estimate'
     #' @param response.arg name of response argument
     #' @param x.arg name of design matrix argument
     #' @param ... optional arguments to fitting function

--- a/R/ml_model.R
+++ b/R/ml_model.R
@@ -74,7 +74,7 @@ ml_model <- R6::R6Class("ml_model", # nolint
     #' @param info optional description of the model
     #' @param predict.args optional arguments to prediction function
     #' @param specials optional additional terms (weights, offset,
-    #'  id, subset, ...) passed to 'estimate'
+    #'  id, subset, ...) passed to [targeted::design] via the special argument
     #' @param response.arg name of response argument
     #' @param x.arg name of design matrix argument
     #' @param ... optional arguments to fitting function

--- a/inst/tinytest/test-ml_model.R
+++ b/inst/tinytest/test-ml_model.R
@@ -1,0 +1,59 @@
+library(tinytest)
+
+n <- 1e3
+ddata <- data.frame(x1 = rnorm(n), x2 = rnorm(n))
+ddata$y <- with(ddata, x1 * 2 - x2 + rnorm(n))
+
+# test various ways to initialize an ml_model
+test_initialize <- function() {
+  # formula supplied + used in estimate function
+  m1 <- ml_model$new(
+    formula = y ~ -1 + x1 + x2,
+    estimate = glm
+  )
+  m1$estimate(ddata)
+
+  # formula supplied + not used in estimate function -> use targeted::design
+  m2 <- ml_model$new(
+    formula = y ~ x1 + x2,
+    estimate = glm.fit,
+    predict = \(object, newdata) newdata %*% object$coefficients
+  )
+  m2$estimate(ddata)
+
+  expect_equal(m1$predict(newdata = ddata), m2$predict(newdata = ddata)[, 1])
+
+  # no formula supplied but passed when estimating model
+  m3 <- ml_model$new(
+    estimate = \(formula, data) glm(formula, data = data)
+  )
+  m3$estimate(data = ddata, formula = y ~ -1 + x1 + x2)
+
+  expect_equal(m1$predict(newdata = ddata), m3$predict(newdata = ddata))
+
+  # test response.arg and x.arg work as expected
+  m4 <- ml_model$new(
+    formula = y ~ x1 + x2,
+    estimate = \(yy, xx) glm.fit(y = yy, x = xx),
+    predict = \(object, newdata) newdata %*% object$coefficients,
+    response.arg = "yy",
+    x.arg = "xx"
+  )
+  m4$estimate(ddata)
+  expect_equal(m1$predict(newdata = ddata), m4$predict(newdata = ddata)[, 1])
+
+  # test that optional arguments are passed on to fitting function
+  ww <- rep(c(0, 1), length.out = n)
+  fit <- glm(y ~ -1 + x1 + x2, data = ddata, weights = ww)
+
+  m1_weights <- ml_model$new(
+    formula = y ~ -1 + x1 + x2,
+    estimate = glm,
+    weights = ww
+  )
+  m1_weights$estimate(ddata)
+  expect_equal(coef(m1_weights$fit), coef(fit))
+  # additional check to verify that weights change the estimates
+  expect_false(all(coef(m1_weights$fit) == coef(m1$fit)))
+}
+test_initialize()

--- a/inst/tinytest/test-ml_model.R
+++ b/inst/tinytest/test-ml_model.R
@@ -57,3 +57,23 @@ test_initialize <- function() {
   expect_false(all(coef(m1_weights$fit) == coef(m1$fit)))
 }
 test_initialize()
+
+# test estimation method
+test_estimate <- function() {
+  # verify that optional arguments are passed on to fitfun
+  ww <- rep(c(0, 1), length.out = n)
+  m1 <- ml_model$new(formula = y ~ x1 + x2, estimate = glm)
+  m1$estimate(ddata, weights = ww)
+
+  fit <- glm(y ~ x1 + x2, data = ddata, weights = ww)
+  expect_equal(coef(m1$fit), coef(fit))
+
+  # arguments to fitfun when supplied during initialization cannot be
+  # overridden during estimate method call
+  m2 <- ml_model$new(formula = y ~ x1 + x2, estimate = glm, weights = ww)
+  expect_error(
+    m2$estimate(data = ddata, weights = ww),
+    pattern = 'formal argument "weights" matched by multiple actual arguments'
+  )
+}
+test_estimate()

--- a/man/ml_model.Rd
+++ b/man/ml_model.Rd
@@ -137,7 +137,7 @@ object, 'object', and new design matrix, 'newdata')}
 \item{\code{info}}{optional description of the model}
 
 \item{\code{specials}}{optional additional terms (weights, offset,
-id, subset, ...) passed to 'estimate'}
+id, subset, ...) passed to \link{design} via the special argument}
 
 \item{\code{response.arg}}{name of response argument}
 

--- a/man/ml_model.Rd
+++ b/man/ml_model.Rd
@@ -137,7 +137,7 @@ object, 'object', and new design matrix, 'newdata')}
 \item{\code{info}}{optional description of the model}
 
 \item{\code{specials}}{optional additional terms (weights, offset,
-id, subset, ...) passed to \link{design} via the special argument}
+id, subset, ...) passed to 'estimate'}
 
 \item{\code{response.arg}}{name of response argument}
 


### PR DESCRIPTION
It is now possible to update the arguments for the estimate and predict function, which are set upon object initialization, when calling the estimate and predict ml_model methods. This is exemplified here for updating the predict.args argument. 
```
m <- ml_model$new(
    formula = y ~ x + offset(w), estimate = glm, family = poisson,
    predict.args = list(type = "link")
  )
m$estimate(data)
m$predict(fit_glm, newdata, type = "response")
```
