### PR TITLE
develop(lintr): return_linter excludes files in inst/ + fix all remaining lint issues in R/

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -7,11 +7,14 @@ linters: linters_with_defaults(
   indentation_linter = NULL,
   brace_linter(allow_single_line = FALSE),
   spaces_left_parentheses_linter = NULL,
-  return_linter(return_style = "explicit")
+  return_linter(return_style = "explicit", except_regex = "^cat|^print|^deprecate")
   )
 encoding: "UTF-8"
 exclusions: list(
     "inst/misc",
     "vignettes",
-    "R/RcppExports.R"
+    "R/RcppExports.R",
+    "inst" = list( # disable return linter for unit tests
+      return_linter = Inf
+    )
   )

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ check:
 	@_R_CHECK_FORCE_SUGGESTS_=0 echo 'res <- rcmdcheck::rcmdcheck(".", build_args=c("--no-build-vignettes"), args=c("--ignore-vignettes"))' | $(R)
 
 lint:
-	@echo 'devtools::lint(".", show_progress = TRUE, exclusions = list("R/RATE.R", "R/intsurv.R", "R/cumhaz.R"))' | $(R)
+	@echo 'lintr::lint_package(show_progress = TRUE, exclusions = list("R/RATE.R", "R/intsurv.R", "R/cumhaz.R"))' | $(R)
 
 test: test-installed
 test-installed: # tests locally installed version package

--- a/R/NB2.R
+++ b/R/NB2.R
@@ -99,5 +99,5 @@ predict.NB2 <- function(object, newdata, threshold=1e-3, ...) {
                 xord, (object$xmodel=="multinomial")*1L,
                 object$prior, threshold)
   colnames(lp) <- object$classes
-  exp(lp)
+  return(exp(lp))
 }

--- a/R/aipw.R
+++ b/R/aipw.R
@@ -38,10 +38,11 @@ aipw <- function(response_model,
   if (inherits(propensity_model, "formula")) {
     propensity_model <- ML(propensity_model, family=binomial)
   }
-  cate(response.model = response_model,
+  res <- cate(response.model = response_model,
        propensity.model = propensity_model,
        cate.model = formula,
       data = data, contrast = 1, stratify = TRUE,
       ...
   )
+  return(res)
 }

--- a/R/alean.R
+++ b/R/alean.R
@@ -136,7 +136,7 @@ alean <- function(response_model,
     mu <- dg(EY) * (Y - EY) + g(EY) - Eg
     A. <- (A - EA)
     if (!silent) pb()
-    cbind(mu, A.)
+    return(cbind(mu, A.))
   }
 
   if (!missing(mc.cores)) {

--- a/R/ate.R
+++ b/R/ate.R
@@ -181,7 +181,7 @@ ate <- function(formula, # nolint
   est <- lava::estimate(coef=coefs, vcov=V, labels=nlabels)
   est$IC <- iids * NROW(iids)
   rownames(est$IC) <- rownames(data)
-  structure(list(estimate=est,
+  obj <- structure(list(estimate=est,
                  outcome.reg=outreg,
                  propensity.model=propmod,
                  names=unlist(nn)[1:2],
@@ -193,6 +193,7 @@ ate <- function(formula, # nolint
                  all=all,
                  family=family),
             class=c("ate.targeted", "targeted"))
+  return(obj)
 }
 
 #' @export
@@ -260,11 +261,11 @@ summary.ate.targeted <- function(object, contrast=c(2:1), ...) {
     if (object$family$family == "binomial") {
       asso <- estimate(object$estimate,
                        function(x) {
-                         c(
+                         return(c(
                            x[contrast[1]] / x[contrast[2]],
                            lava::OR(x[contrast]),
                            x[contrast[1]] - x[contrast[2]]
-                         )
+                         ))
                        },
                        labels = c("RR", "OR", "RD")
                        )
@@ -275,7 +276,7 @@ summary.ate.targeted <- function(object, contrast=c(2:1), ...) {
                        )
     }
   }
-  structure(list(estimate=cc, npar=nn, type=object$type, asso=asso,
+  obj <- structure(list(estimate=cc, npar=nn, type=object$type, asso=asso,
                  family=object$family,
                  names=c(object$names, "",
                          "Outcome model:", "Propensity model:"),
@@ -284,4 +285,5 @@ summary.ate.targeted <- function(object, contrast=c(2:1), ...) {
                               unlist(lapply(object$formula, deparse))),
                  contrast=contrast),
             class="summary.ate.targeted")
+  return(obj)
 }

--- a/R/cate_link.R
+++ b/R/cate_link.R
@@ -106,7 +106,9 @@ crr <- function(treatment,
   response_var <- lava::getoutcome(response_model$formula, data=data)
   treatment_var <- lava::getoutcome(treatment)
   treatment_f <- function(treatment_level, x = paste0(".-", response_var)) {
-    as.formula(paste0("I(", treatment_var, "==", treatment_level, ") ~ ", x))
+    return(
+      as.formula(paste0("I(", treatment_var, "==", treatment_level, ") ~ ", x))
+    )
   }
   if (missing(propensity_model)) {
     propensity_model <- SL(treatment_f(contrast[1]), ..., binomial=TRUE)
@@ -157,11 +159,11 @@ crr <- function(treatment,
 
   if (type=="dml1") {
     est1 <- lapply(folds, function(x) {
-      cate_fold1(x,
+      return(cate_fold1(x,
         data = data,
         score = score,
         cate_des = desA
-      )
+      ))
     })
     est <- colMeans(Reduce(rbind, est1))
   } else {
@@ -254,7 +256,9 @@ cate_link <- function(treatment,
   response_var <- lava::getoutcome(response_model$formula, data=data)
   treatment_var <- lava::getoutcome(treatment)
   treatment_f <- function(treatment_level, x = paste0(".-", response_var)) {
-    as.formula(paste0("I(", treatment_var, "==", treatment_level, ") ~ ", x))
+    return(
+      as.formula(paste0("I(", treatment_var, "==", treatment_level, ") ~ ", x))
+    )
   }
   if (missing(propensity_model)) {
     propensity_model <- SL(treatment_f(contrast[1]), ..., binomial=TRUE)
@@ -316,11 +320,11 @@ cate_link <- function(treatment,
 
   if (type=="dml1") {
     est1 <- lapply(folds, function(x) {
-      cate_fold1(x,
+      return(cate_fold1(x,
         data = data,
         score = score,
         cate_des = desA
-      )
+      ))
     })
     est <- colMeans(Reduce(rbind, est1))
   } else {

--- a/R/cv.R
+++ b/R/cv.R
@@ -91,7 +91,7 @@ cv <- function(models, data, # nolint
       models[[i]] <- list(
         fit = f,
         predict = function(fit, newdata, ...) {
-          predict(fit, newdata = newdata, ...)
+          return(predict(fit, newdata = newdata, ...))
         }
       )
     }
@@ -250,7 +250,7 @@ cv <- function(models, data, # nolint
       perfs <- c(perfs, list(newperf))
     }
     if (!silent) pb()
-    do.call(rbind, perfs)
+    return(do.call(rbind, perfs))
   }
 
   if (missing(mc.cores)) {
@@ -274,7 +274,7 @@ cv <- function(models, data, # nolint
     perf_arr[R, k, , ] <- val[[i]]
   }
 
-  structure(list(
+  obj <- structure(list(
     cv = perf_arr,
     call = match.call(),
     names = nam,
@@ -283,6 +283,7 @@ cv <- function(models, data, # nolint
   ),
   class = "cross_validated"
   )
+  return(obj)
 }
 
 #' @export
@@ -308,7 +309,7 @@ coef.cross_validated <- function(object, min=FALSE, ...) {
   if (min) {
     res <- apply(res, 2, which.min)
   }
-  res
+  return(res)
 }
 
 #' @export

--- a/R/design.R
+++ b/R/design.R
@@ -39,7 +39,7 @@ design <- function(formula, data, intercept=FALSE,
                 data=data[0, ], ## Empty data.frame to capture structure of data
                 specials=specials),
            specials_list)
-  structure(res, class="design")
+  return(structure(res, class="design"))
 }
 
 #' @export
@@ -79,7 +79,7 @@ model.matrix.design <- function(object, drop.intercept = FALSE, ...) {
 
 #' @export
 weights.design <- function(object, ...) {
-  specials(object, "weights")
+  return(specials(object, "weights"))
 }
 
 #' @export
@@ -87,7 +87,7 @@ offsets <- function(object, ...) UseMethod("offsets")
 
 #' @export
 offsets.design <- function(object, ...) {
-  specials(object, "offset")
+  return(specials(object, "offset"))
 }
 
 #' @export

--- a/R/expand.list.R
+++ b/R/expand.list.R
@@ -31,15 +31,16 @@ expand.list <- function(...) {
   names(dots) <- nam
   dat <- do.call(expand.grid, c(dots,
             list(KEEP.OUT.ATTRS = FALSE, stringsAsFactors = FALSE)))
-  res <- lapply(seq_len(NROW(dat)),
-                function(i) {
-                  res <- as.list(dat[i, ])
-                  if (length(nulls)>0) res[nulls] <- list(NULL)
-                  if (length(formulas)>0) {
-                    res[[formulas]] <- as.formula(res[[formulas]])
-                    environment(res[[formulas]]) <- baseenv()
-                  }
-                  res
-                })
-  structure(res, table=dat)
+  fun <- function(i) {
+    res <- as.list(dat[i, ])
+    if (length(nulls)>0) res[nulls] <- list(NULL)
+    if (length(formulas)>0) {
+      res[[formulas]] <- as.formula(res[[formulas]])
+      environment(res[[formulas]]) <- baseenv()
+    }
+    return(res)
+  }
+  res <- lapply(seq_len(NROW(dat)), fun)
+
+  return(structure(res, table=dat))
 }

--- a/R/ode.R
+++ b/R/ode.R
@@ -101,7 +101,7 @@ solve_ode <- function(ode_ptr, input, init, par=0) {
   if (is.function(ode_ptr)) {
     return(.ode_solve2(ode_ptr, cbind(input), rbind(init), rbind(par)))
   }
-  .ode_solve(ode_ptr, cbind(input), rbind(init), rbind(par))
+  return(.ode_solve(ode_ptr, cbind(input), rbind(init), rbind(par)))
 }
 
 ## Dormand-Prince method. Adaptive step-size, see E. Hairer, S. P. Norsett G.

--- a/R/predict.NB.R
+++ b/R/predict.NB.R
@@ -87,5 +87,5 @@ predict.NB <- function(object, newdata, # nolint
     }
   }
   colnames(lposterior) <- object$classes
-  exp(lposterior)
+  return(exp(lposterior))
 }

--- a/R/predictor.R
+++ b/R/predictor.R
@@ -1,7 +1,5 @@
 #' @export
-predictor <- function(...) {
-  ml_model$new(...)
-}
+predictor <- function(...) return(ml_model$new(...))
 
 predictor_argument_description <- function(call) {
     ar <- lapply(
@@ -25,17 +23,12 @@ predictor_glm <- function(formula,
                           ...) {
   args <- c(as.list(environment(), all.names = FALSE), list(...))
     args$estimate <- function(formula, data, family, ...) {
-    stats::glm(formula,
-               data = data,
-               family = family,
-      ...
+    return(
+      stats::glm(formula, data = data, family = family, ...)
     )
   }
   args$predict <- function(object, newdata, ...) {
-    stats::predict(object,
-      newdata = newdata,
-      type = "response"
-    )
+    return(stats::predict(object, newdata = newdata, type = "response"))
   }
   args$offset <- NULL
   mod <- do.call(ml_model$new, args)
@@ -63,19 +56,13 @@ predictor_glmnet <- function(formula,
       )
       return(res)
     }
-    glmnet::glmnet(
-      x = x, y = y,
-      ...
+    return(glmnet::glmnet(x = x, y = y, ...)
     )
   }
   pred <- function(object, newdata, ...) {
-    predict(object,
-      newx = newdata,
-      family = family,
-      type = "response",
-      s = "lambda.min",
-      ...
-    )
+    res <- predict(object, newx = newdata, family = family, type = "response",
+      s = "lambda.min", ...)
+    return(res)
   }
   mod <- ml_model$new(
     formula = formula,
@@ -94,9 +81,6 @@ predictor_glmnet <- function(formula,
   return(mod)
 }
 
-
-
-
 #' @export
 predictor_hal <- function(formula,
                           info = "hal9001::fit_hal",
@@ -105,11 +89,7 @@ predictor_hal <- function(formula,
                           family = "gaussian",
                           ...) {
   est <- function(y, x, ...) {
-    hal9001::fit_hal(
-      X = x,
-      Y = y,
-      ...
-    )
+    return(hal9001::fit_hal(X = x, Y = y, ...))
   }
   pred <- function(fit, newdata, offset = NULL, ...) {
     res <- predict(fit,
@@ -119,7 +99,7 @@ predictor_hal <- function(formula,
     )
     return(res)
   }
-  ml_model$new(formula = formula,
+  mod <- ml_model$new(formula = formula,
              estimate = est,
              predict = pred,
              info = info,
@@ -128,7 +108,8 @@ predictor_hal <- function(formula,
              reduce_basis = reduce_basis,
              family = family,
              ...
-             )
+  )
+  return(mod)
 }
 
 #' @export
@@ -141,14 +122,10 @@ predictor_gam <- function(formula,
   args <- list(
     formula = formula,
     estimate = function(formula, data, ...) {
-      mgcv::gam(
-        formula = formula,
-        data = data,
-        ...
-      )
+      return(mgcv::gam(formula = formula, data = data, ...))
     },
     predict = function(object, newdata) {
-      stats::predict(object, newdata = newdata, type = "response")
+      return(stats::predict(object, newdata = newdata, type = "response"))
     },
     family = family,
     select = select,
@@ -172,12 +149,8 @@ predictor_isoreg <- function(formula,
   }
   mod <- ml_model$new(formula,
     info = info,
-    estimate = function(y, x, ...) {
-      isoregw(y = y, x = x)
-    },
-    predict = function(object, newdata, ...) {
-      object(newdata)
-    },
+    estimate = function(y, x, ...) return(isoregw(y = y, x = x)),
+    predict = function(object, newdata, ...) return(object(newdata)),
     ...
     )
   mod$description <- predictor_argument_description(
@@ -257,10 +230,7 @@ predictor_sl <- function(model.list,
   args$info <- info
   args <- c(args, list(
     estimate = function(data, ...) {
-      superlearner(
-        data = data,
-        ...
-      )
+      return(superlearner(data = data, ...))
     },
     predict = function(object, newdata, all.learners = FALSE, ...) {
       pr <- lapply(object$fit, \(x) x$predict(newdata))
@@ -308,7 +278,7 @@ score_sl <- function(response, prediction, weights, object, newdata, ...) {
     names(res) <- paste0("score.", nn)
     w <- weights(object)
     names(w) <- paste0("weight.", nn[-1])
-    c(res, w)
+    return(c(res, w))
 }
 
 #' @export
@@ -318,7 +288,7 @@ summary.predictor_sl <- function(object, data, nfolds = 5, rep = 1, ...) {
       nfolds = nfolds, rep = rep,
       model.score = score_sl
       )
-  res
+  return(res)
 }
 
 #' @export
@@ -340,13 +310,13 @@ predictor_xgboost <-
     }
     pred <- function(object, newdata, ...) {
       d <- xgboost::xgb.DMatrix(newdata)
-      predict(object, d, ...)
+      return(predict(object, d, ...))
     }
     if (objective == "multi:softprob") {
       pred <- function(object, newdata, ...) {
         d <- xgboost::xgb.DMatrix(newdata)
         val <- predict(object, d, ...)
-        matrix(val, nrow = NROW(d), byrow = TRUE)
+        return(matrix(val, nrow = NROW(d), byrow = TRUE))
       }
     }
     args$predict <- pred
@@ -361,11 +331,8 @@ predictor_xgboost <-
         )
         nrounds <- which.min(val$evaluation_log[[4]])
       }
-      xgboost::xgboost(
-        d,
-        nrounds = nrounds,
-        ...
-      )
+      res <- xgboost::xgboost(d, nrounds = nrounds, ...)
+      return(res)
     }
     mod <- do.call(ml_model$new, args)
     mod$description <- predictor_argument_description(
@@ -376,22 +343,22 @@ predictor_xgboost <-
 
 #' @export
 predictor_xgboost_multiclass <- function(formula, ...) {
-  predictor_xgboost(formula, ..., objective="multi:softprob")
+  return(predictor_xgboost(formula, ..., objective="multi:softprob"))
 }
 
 #' @export
 predictor_xgboost_binary <- function(formula, ...) {
-  predictor_xgboost(formula, ..., objective="reg:logistic")
+  return(predictor_xgboost(formula, ..., objective="reg:logistic"))
 }
 
 #' @export
 predictor_xgboost_count <- function(formula, ...) {
-  predictor_xgboost(formula, ..., objective="count:poisson")
+  return(predictor_xgboost(formula, ..., objective="count:poisson"))
 }
 
 #' @export
 predictor_xgboost_cox <- function(formula, ...) {
-  predictor_xgboost(formula, ..., objective="survival:cox")
+  return(predictor_xgboost(formula, ..., objective="survival:cox"))
 }
 
 #' @export
@@ -408,11 +375,11 @@ predictor_grf <- function(formula,
   args$model <- NULL
   est <- utils::getFromNamespace(gsub("^grf::", "", model), "grf")
   pred <- function(object, newdata, ...) {
-    predict(object, newdata, ...)$predictions
+    return(predict(object, newdata, ...)$predictions)
   }
   args$predict <- pred
   args$estimate <- function(x, y, ...) {
-      est(X = x, Y = y, ...)
+      return(est(X = x, Y = y, ...))
   }
   mod <- do.call(ml_model$new, args)
   mod$description <- predictor_argument_description(
@@ -425,10 +392,11 @@ predictor_grf <- function(formula,
 #' @export
 predictor_grf_binary <- function(formula,
                                  ...) {
-  predictor_grf(formula,
+  mod <- predictor_grf(formula,
     model = "grf::probability_forest",
     ...
-   )
+  )
+  return(mod)
 }
 
 

--- a/R/riskreg.R
+++ b/R/riskreg.R
@@ -150,27 +150,31 @@ riskreg_mle <- function(y, a, x1, x2=x1,
     x2 <- cbind(x2)
     type <- substr(type, 1, 2)
     f <- function(p) {
-      -as.vector(bin_logl(
+      res <- -as.vector(bin_logl(
         y = y, a = cbind(a),
         x1 = cbind(x1), x2 = cbind(x2),
         par = p, weights = weights, type = type
       ))
+      return(res)
     }
     df <- function(p, ...) {
-      -bin_dlogl(
+      res <- -bin_dlogl(
         y = y, a = cbind(a),
         x1 = cbind(x1), x2 = cbind(x2),
         par = p, weights = weights, type = type, ...
       )
+      return(res)
     }
     d2f <- function(theta) {
-      deriv(function(p) {
-        -bin_dlogl_c(
+      res <- deriv(function(p) {
+        res_inner <- -bin_dlogl_c(
           y = y, a = cbind(a),
           x1 = cbind(x1), x2 = cbind(x2),
           par = p, weights = weights, type = type
         )
+        return(res_inner)
       }, theta)
+      return(res)
     }
     # Starting values
     if (is.null(start))
@@ -193,10 +197,11 @@ riskreg_mle <- function(y, a, x1, x2=x1,
     }
     est$IC <- ii * NROW(ii)
     rownames(est$IC) <- rownames(cbind(y))
-    structure(list(estimate=est, npar=c(ncol(x1), ncol(x2)),
+    obj <- structure(list(estimate=est, npar=c(ncol(x1), ncol(x2)),
                    logLik=loglik, nobs=length(y),
                    opt=op, bread=V*NROW(ii), type=type, estimator="mle"),
               class=c("riskreg.targeted", "targeted"))
+    return(obj)
 }
 
 
@@ -293,13 +298,13 @@ riskreg_fit <- function(y, a, # nolint
           length(alpha.index) + length(theta.index)
         pp <- c(alphahat, thetahat)
         U <- function(p) {
-          bin_esteq_c(
+          return(bin_esteq_c(
             y = y, a = a,
             x1 = target, x2 = nuisance, x3 = propensity,
             alpha = p[seq_along(alphahat)],
             par = p[seq_along(thetahat) + length(alphahat)],
             weights = weights1, type = type
-          )
+          ))
         }
         DU  <- deriv(U, pp)
         U0 <- u(alphahat, indiv=TRUE)
@@ -323,12 +328,13 @@ riskreg_fit <- function(y, a, # nolint
     est$IC <- ii * NROW(ii)
     rownames(est$IC) <- rownames(cbind(y))
     propmod <- lava::estimate(coef=coef(propmod), vcov=Vprop, colnames)
-  structure(list(estimate=est, opt=opt,
+  obj <- structure(list(estimate=est, opt=opt,
                  npar=c(ncol(target), ncol(nuisance), ncol(propensity)),
                  nobs=length(y),
                  mle=mle, prop=propmod, type=type,
                  estimator="dre"),
               class=c("riskreg.targeted", "targeted"))
+  return(obj)
 }
 
 
@@ -389,7 +395,7 @@ summary.riskreg.targeted <- function(object, ...) {
           labels = rownames(cc)
           )
     }
-    structure(
+    obj <- structure(
       list(
         estimate = cc,
         npar = object$npar,
@@ -399,6 +405,7 @@ summary.riskreg.targeted <- function(object, ...) {
       ),
       class = "summary.riskreg.targeted"
     )
+    return(obj)
 }
 
 

--- a/R/scoring.R
+++ b/R/scoring.R
@@ -21,8 +21,11 @@ mae <- function(response, prediction, weights=NULL, ...) {
 }
 
 quantitative_scoring1 <- function(response, prediction, weights=NULL, ...) {
-  c(mse(response, prediction, weights=weights, ...),
-    mae(response, prediction, weights=weights, ...))
+  res <- c(
+    mse(response, prediction, weights=weights, ...),
+    mae(response, prediction, weights=weights, ...)
+  )
+  return(res)
 }
 
 multiclass_scoring1 <- # nolint

--- a/R/softmax.R
+++ b/R/softmax.R
@@ -10,5 +10,5 @@ softmax <- function(x, log=FALSE, ref=TRUE, ...) {
     if (is.vector(x) || NCOL(x)==1) {
         return(.softmax(cbind(x), log=log, ref=TRUE)[, -1, drop=is.vector(x)])
     }
-    .softmax(cbind(x), log=log, ref=ref)
+    return(.softmax(cbind(x), log=log, ref=ref))
 }

--- a/R/targeted-methods.R
+++ b/R/targeted-methods.R
@@ -49,14 +49,15 @@ print.summary.targeted <- function(x, ...) {
 
 #' @export
 summary.targeted <- function(object, ...) {
-  structure(list(estimate = object$estimate, call = object$call),
+  obj <- structure(list(estimate = object$estimate, call = object$call),
     class = "summary.targeted"
   )
+  return(obj)
 }
 
 #' @export
 IC.targeted <- function(x, ...) {
-  lava::IC(x$estimate, ...)
+  return(lava::IC(x$estimate, ...))
 }
 
 #' @export
@@ -65,18 +66,19 @@ logLik.targeted <- function(object, ...) {
   if (is.null(val)) {
     return(NULL)
   }
-  structure(val,
+  obj <- structure(val,
     nobs = object$nobs, nall = object$nobs, df = length(coef(object)),
     class = "logLik"
   )
+  return(obj)
 }
 
 #' @export
 vcov.targeted <- function(object, ...) {
-  vcov(object$estimate, ...)
+  return(vcov(object$estimate, ...))
 }
 
 #' @export
 coef.targeted <- function(object, ...) {
-  coef(object$estimate, ...)
+  return(coef(object$estimate, ...))
 }

--- a/R/truncatedscore.R
+++ b/R/truncatedscore.R
@@ -1,19 +1,21 @@
 qprob <- function(corr) {
-  0.5 - mets::pmvn(upper = cbind(0, 0), sigma = corr, cor = TRUE)
+  return(0.5 - mets::pmvn(upper = cbind(0, 0), sigma = corr, cor = TRUE))
 }
 
 prob_fct <- function(x, alpha, corr) {
   q <- qprob(corr)
-  0.5 * pchisq(x, 1, lower.tail = FALSE) +
+  res <- 0.5 * pchisq(x, 1, lower.tail = FALSE) +
     q * pchisq(x, 2, lower.tail = FALSE) - alpha
+  return(res)
 }
 
 q_fct <- function(alpha, corr) {
-  uniroot(prob_fct,
+  root <- uniroot(prob_fct,
           alpha = alpha,
           corr = corr,
           interval = c(0, 10)
   )$root
+  return(root)
 }
 
 ###############################################################
@@ -94,12 +96,13 @@ test_intersectsignedwald <- function(thetahat1,
     # estimate = 1
   ), class = "htest")
 
-  list(
+  res <- list(
     critval.intersect = critval.intersect,
     test.intersect = test.int,
     test.1 = test.1,
     test.2 = test.2
   )
+  return(res)
 
 }
 
@@ -341,9 +344,9 @@ print.summary.truncatedscore <- function(x, ...) {
 
 #' @export
 parameter.summary.truncatedscore <- function(x, ...) {
-  x$tests
+  return(x$tests)
 }
 #' @export
 coef.summary.truncatedscore <- function(object, ...) {
-  object$tests
+  return(object$tests)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,5 @@
 Identical <- function(x, y = 1, tolerance = .Machine$double.eps^0.5) {
-  Mod(x - y) < tolerance
+  return(Mod(x - y) < tolerance)
 }
 
 rd2pr <- function(rd, op) {
@@ -13,7 +13,7 @@ rd2pr <- function(rd, op) {
     p0[op1] <- 0.5 * (1 - rd[op1])
   }
   p1 <- p0 + rd
-  cbind(p0, p1)
+  return(cbind(p0, p1))
 }
 
 rr2pr <- function(rr, op) {
@@ -27,7 +27,7 @@ rr2pr <- function(rr, op) {
     p0[op1] <- 1 / (1 + rr[op1])
   }
   p1 <- p0 * rr
-  cbind(p0, p1)
+  return(cbind(p0, p1))
 }
 
 add_offset <- function(formula, offset) {


### PR DESCRIPTION
- **change lint make target to lintr::lint_package to match behavior of github workflow + prevent return linter from linting files in inst/**
- **fix predictor**
- **truncatedscore + utils**
- **riskreg + targeted-methods**
- **cv + expand.list**
- **cate_link + design + scoring**
- **aipw + alean + ate**
- **NB2 + ode + predict.NB + softmax**
