### PR TITLE
feat(ml_model): improving print method

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -7,7 +7,7 @@ linters: linters_with_defaults(
   indentation_linter = NULL,
   brace_linter(allow_single_line = FALSE),
   spaces_left_parentheses_linter = NULL,
-  return_linter(return_style = "explicit", except_regex = "^cat|^print|^deprecate")
+  return_linter = NULL
   )
 encoding: "UTF-8"
 exclusions: list(

--- a/R/ml_model.R
+++ b/R/ml_model.R
@@ -179,7 +179,7 @@ ml_model <- R6::R6Class("ml_model", # nolint
         estimate = formals(estimate),
         predict = formals(predict)
       )
-      private$init <- list( # nolint
+      private$init <- list(
         estimate.args = list(...),
         predict.args = predict.args
       )

--- a/R/ml_model.R
+++ b/R/ml_model.R
@@ -60,8 +60,6 @@ ml_model <- R6::R6Class("ml_model", # nolint
     #' @field args optional arguments to fitting function specified during
     #' initialization
     args = NULL,
-    #' @field description optional description field
-    description = NULL,
 
     #' @description
     #' Create a new prediction model object
@@ -181,11 +179,9 @@ ml_model <- R6::R6Class("ml_model", # nolint
         estimate = formals(estimate),
         predict = formals(predict)
       )
-      private$call <- list( # nolint
-        estimate = substitute(estimate),
-        predict = substitute(predict),
-        argslist = substitute(dots),
-        predict.args = substitute(predict.args)
+      private$init <- list( # nolint
+        estimate.args = list(...),
+        predict.args = predict.args
       )
     },
 
@@ -231,56 +227,7 @@ ml_model <- R6::R6Class("ml_model", # nolint
     #' @description
     #' Print method
     print = function() {
-      cat(
-        "Prediction Model (class ml_model)",
-        "\n_________________________________\n\n"
-      )
-      if (!is.null(self$info)) {
-        cat(self$info, "\n\n")
-      }
-
-      if (!is.null(self$description)) {
-        cat(self$description)
-      } else {
-        cat("Arguments:\n")
-        argslist <- gsub("^list\\(", "",
-          deparse(private$call$argslist),
-          perl = TRUE
-        )
-        argslist <- gsub("\\)$", "", argslist)
-        argslist <- strsplit(
-          paste(argslist, collapse = ""),
-          ","
-        ) |>
-          _[[1]] |>
-          lapply(lava::trim) |>
-          unlist()
-        cat(
-          paste0("\t", paste(argslist, collapse = "\n\t")),
-          "\n",
-          sep = ""
-        )
-      }
-
-      ## if (!is.null(self$formula)) {
-      ##   cat("Model:\n",
-      ##     "\t", deparse1(self$formula), "\n",
-      ##     sep = ""
-      ##   )
-      ## }
-      ## cat("\`estimate` method:`\n",
-      ##     "\tfunction(", paste(names(self$formals[[1]]),
-      ##                          collapse=", "), ")\n", sep="")
-      ## cat("`predict` method:\n",
-      ##   "\tfunction(", paste(names(self$formals[[2]]),
-      ##     collapse = ", "
-      ##   ), ")\n",
-      ## sep = ""
-      ## )
-      if (!is.null(self$fit)) {
-        cat("\n_________________________________\n\n")
-        print(self$fit)
-      }
+      ml_model_print(self, private)
       return(invisible())
     },
 
@@ -332,8 +279,8 @@ ml_model <- R6::R6Class("ml_model", # nolint
     fitfun = NULL,
     # @field fitted Fitted model object
     fitted = NULL,
-    # @field call Information on the initialized model
-    call = NULL,
+    # @field init Information on the initialized model
+    init = NULL,
     # @field optional field containing name of response variable
     responsevar = NULL,
     # When x$clone(deep=TRUE) is called, the deep_clone gets invoked once for
@@ -379,4 +326,51 @@ estimate.ml_model <- function(x, ...) {
 #' @export
 predict.ml_model <- function(object, ...) {
   return(object$predict(...))
+}
+
+format_fit_predict_args <- function(args) {
+  if (length(args) == 0) return(" ")
+  funs <- c(is.numeric, is.character, is.integer, is.logical, is.null)
+
+  # print family attribute of family objects instead of printing only that the
+  # argument is of class <family>
+  mask <- unlist(lapply(args, \(x) inherits(x, "family")))
+  vals <- lapply(args[mask], \(x) x$family)
+  args[mask] <- vals
+
+  mask <- unlist(lapply(args, \(x) any(sapply(funs, \(f) f(x)))))
+  args_class <- paste0("<", lapply(args, \(x) class(x)[[1]]), ">")
+  args[!mask] <- args_class[!mask]
+
+  return(paste0(names(args), "=", args, collapse =", "))
+}
+
+ml_model_print <- function(self, private) {
+  .ruler <- function(x, n, unicode = "\u2500") {
+    rule <- paste0(rep(unicode, n), collapse = "")
+    cat(paste0(rule, x, rule, "\n"))
+  }
+
+  .ruler(" ml_model object ", 10)
+
+  if (!is.null(self$info)) {
+    cat(self$info, "\n\n")
+  }
+
+  cat(
+    "Estimate arguments:",
+    format_fit_predict_args(private$init$estimate.args),
+    "\nPredict arguments:",
+    format_fit_predict_args(private$init$predict.args),
+    "\nFormula:",
+    capture.output(print(self$formula)),
+    "\n"
+  )
+
+  if (!is.null(private$fitted)) {
+    .ruler("\u2500", 18)
+    cat(capture.output(print(self$fit)), sep ="\n")
+  }
+
+  return(invisible())
 }

--- a/R/predictor.R
+++ b/R/predictor.R
@@ -1,19 +1,6 @@
 #' @export
 predictor <- function(...) return(ml_model$new(...))
 
-predictor_argument_description <- function(call) {
-    ar <- lapply(
-      rlang::call_args(call),
-      deparse
-    )
-    ar["info"] <- NULL
-    nn <- names(ar)
-    desc <- "Arguments:\n"
-    for (i in seq_along(nn)) {
-      desc <- paste0(desc, "\t", nn[i], " = ", ar[i], "\n")
-    }
-    return(desc)
-  }
 
 #' @export
 predictor_glm <- function(formula,
@@ -32,9 +19,7 @@ predictor_glm <- function(formula,
   }
   args$offset <- NULL
   mod <- do.call(ml_model$new, args)
-  mod$description <- predictor_argument_description(
-    rlang::call_match(defaults = TRUE)
-  )
+
   return(mod)
 }
 
@@ -75,9 +60,7 @@ predictor_glmnet <- function(formula,
     nfolds = nfolds,
     ...
     )
-  mod$description <- predictor_argument_description(
-    rlang::call_match(defaults = TRUE)
-  )
+
   return(mod)
 }
 
@@ -134,9 +117,7 @@ predictor_gam <- function(formula,
     ...
   )
   mod <- do.call(ml_model$new, args)
-  mod$description <- predictor_argument_description(
-    rlang::call_match(defaults = TRUE)
-  )
+
   return(mod)
 }
 
@@ -153,9 +134,7 @@ predictor_isoreg <- function(formula,
     predict = function(object, newdata, ...) return(object(newdata)),
     ...
     )
-  mod$description <- predictor_argument_description(
-    rlang::call_match(defaults = TRUE)
-  )
+
   return(mod)
 }
 
@@ -251,7 +230,7 @@ predictor_sl <- function(model.list,
   mod$update(model.list[[1]]$formula)
   cl <- rlang::call_match(defaults = TRUE)
   cl$formula <- lapply(model.list, \(x) x$formula)
-  mod$description <- predictor_argument_description(cl)
+
   class(mod) <- c("predictor_sl", class(mod))
   return(mod)
 }
@@ -335,9 +314,7 @@ predictor_xgboost <-
       return(res)
     }
     mod <- do.call(ml_model$new, args)
-    mod$description <- predictor_argument_description(
-      rlang::call_match(defaults = TRUE)
-    )
+
     return(mod)
   }
 
@@ -382,9 +359,7 @@ predictor_grf <- function(formula,
       return(est(X = x, Y = y, ...))
   }
   mod <- do.call(ml_model$new, args)
-  mod$description <- predictor_argument_description(
-    rlang::call_match(defaults = TRUE)
-  )
+
   return(mod)
 }
 

--- a/R/targeted-package.R
+++ b/R/targeted-package.R
@@ -21,7 +21,7 @@
 #' @importFrom data.table data.table is.data.table
 #' @importFrom R6 R6Class
 #' @importFrom survival survfit
-#' @importFrom utils tail head
+#' @importFrom utils tail head capture.output
 #' @useDynLib targeted, .registration=TRUE
 #' @aliases targeted-package targeted
 #' @author Klaus K. Holst (Maintainer) <klaus@@holst.it>

--- a/vignettes/example-print.qmd
+++ b/vignettes/example-print.qmd
@@ -1,0 +1,76 @@
+---
+format:
+    html:
+      toc: true
+---
+
+# Custom model
+
+```{r}
+devtools::load_all(".")
+
+ff <- function(object, newdata) newdata %*% object$coefficients
+m <- ml_model$new(
+  formula = y ~ x1 + x2,
+  estimate = glm.fit,
+  predict = ff,
+  info = "some info about the model",
+  predict.args = list(some_predict_arg = 1, family = gaussian(inverse)),
+  some.fit.arg = "sdfsd",
+  another_fit_arg = gaussian
+)
+```
+
+```{r}
+print(m)
+```
+
+# predictor_
+
+## glmnet
+```{r}
+m <- predictor_glmnet(y ~ a * (x1 + x2))
+m
+```
+
+## glm
+```{r, attr.output='style="max-height: 700px;"'}
+m <- predictor_glm(y ~ a * (x1 + x2))
+print(m)
+```
+
+## gam
+```{r, attr.output='style="max-height: 700px;"'}
+m <- predictor_gam(y ~ a * (x1 + x2))
+print(m)
+```
+
+## sl
+sl needs some additional care
+```{r, attr.output='style="max-height: 700px;"'}
+m <- predictor_sl(list(
+  gam = predictor_gam(y ~ a * (x1 + x2)),
+  glm = predictor_glm(y ~ a * (x1 + x2))
+)
+)
+print(m)
+```
+
+# fitted model
+
+
+```{r}
+sim1 <- function(n = 5e2) {
+   n <- 5e2
+   x1 <- rnorm(n, sd = 2)
+   x2 <- rnorm(n)
+   y <- x1 + cos(x1) + rnorm(n, sd = 0.5**.5)
+   d <- data.frame(y, x1, x2)
+   d
+}
+d <- sim1()
+m <- predictor_glm(y ~ x1 + x2)
+m
+m$estimate(d)
+m
+```


### PR DESCRIPTION
New `ml_model$print` method which shows the most essential information about an object. That is, the formula, predict and estimate arguments provided during object instantiation. If a model has been fitted via the specified estimation function, then also the return object by the estimation function is printed. `predictor_argument_description` is removed because the information about estimate arguments of `predictor_` functions is now captured by the print method, and must therefore not been handled via the `description` field of an `ml_model` object.  I will implement a `ml_model$summary` method, or the like, to also provide information about the estimate and predict function, in another PR.