### PR TITLE
develop(Makefile): use `build_dir` var in `check-cran` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ dependencies-upgrade:
 	@echo 'devtools::install(".", upgrade = "always")' | $(R)
 
 check-cran: build
-	@$(R) CMD check build/$(PKG)_$(GETVER).tar.gz --timings --as-cran --no-multiarch --run-donttest
+	@$(R) CMD check $(BUILD_DIR)/$(PKG)_$(GETVER).tar.gz --timings --as-cran --no-multiarch --run-donttest
 
 check:
 	@_R_CHECK_FORCE_SUGGESTS_=0 echo 'res <- rcmdcheck::rcmdcheck(".", build_args=c("--no-build-vignettes"), args=c("--ignore-vignettes"))' | $(R)


### PR DESCRIPTION
Minor fix.
