### PR TITLE
Fix/learner formula

### DIFF
--- a/.github/workflows/r_check.yaml
+++ b/.github/workflows/r_check.yaml
@@ -6,8 +6,6 @@ on:
     branches: [main, dev]
     # types: [opened, synchronize, reopened, ready_for_review]
 
-name: r-cmd-check
-
 jobs:
   r-cmd-check:
     runs-on: ${{ matrix.config.os }}

--- a/R/cate.R
+++ b/R/cate.R
@@ -7,7 +7,7 @@ ate_if_fold <- function(fold, data,
   } else {
     dtrain <- data[-fold, ]
     deval <- data[fold, ]
- }
+  }
 
   pmod <- propensity.model$estimate(dtrain)
   X <- deval

--- a/R/learner.R
+++ b/R/learner.R
@@ -121,14 +121,14 @@ learner <- R6::R6Class("learner", # nolint
           private$fitfun <- function(data, ...) {
             des <- do.call(
               targeted::design,
-              c(list(formula = private$.formula,
+              c(list(formula = self$formula,
                      data = data,
                      design.matrix = FALSE),
                 private$des.args
                 )
             )
             args <- private$update_args(private$estimate.args, ...) #
-            form <- private$.formula
+            form <- self$formula
             if (!private$formula.keep.specials) form <- des$formula
             args <- c(
               args, list(formula = form, data = data)
@@ -145,7 +145,7 @@ learner <- R6::R6Class("learner", # nolint
           private$fitfun <- function(data, ...) {
             xx <- do.call(
               targeted::design,
-              c(list(formula = private$.formula, data = data), private$des.args)
+              c(list(formula = self$formula, data = data), private$des.args)
             )
             args <- private$update_args(private$estimate.args, ...)
             args <- c(list(x = xx$x, y = xx$y), args)
@@ -264,7 +264,7 @@ learner <- R6::R6Class("learner", # nolint
     #' print(lr_sum)
     summary = function() {
       obj <- structure(
-        c(list(formula = private$.formula, info = self$info), private$init),
+        c(list(formula = self$formula, info = self$info), private$init),
         class = "summarized_learner"
       )
       return(obj)
@@ -279,8 +279,8 @@ learner <- R6::R6Class("learner", # nolint
       if (eval) {
         return(self$design(data = data, ..., design.matrix = FALSE)$y)
       }
-      if (is.null(private$.formula)) return(NULL)
-      newf <- update(private$.formula, ~1)
+      if (is.null(self$formula)) return(NULL)
+      newf <- update(self$formula, ~1)
       return(data[, all.vars(newf), drop = TRUE])
     },
 
@@ -290,7 +290,7 @@ learner <- R6::R6Class("learner", # nolint
     design = function(data, ...) {
       args <- c(private$des.args, list(data = data))
       args[...names()] <- list(...)
-      return(do.call(design, c(list(private$.formula), args)))
+      return(do.call(design, c(list(self$formula), args)))
     },
 
     #' @description
@@ -302,10 +302,15 @@ learner <- R6::R6Class("learner", # nolint
   ),
   active = list(
     #' @field fit Return estimated model object.
-    fit = function() private$fitted,
+    fit = function(value) {
+      if (missing(value)) return(private$fitted)
+      else private$fitted <- value
+    },
     #' @field formula Return model formula. Use [learner$update()][learner] to
     #' update the formula.
-    formula = function() private$.formula
+    formula = function() {
+      private$.formula
+    }
   ),
   private = list(
     # @field des.args Arguments for targeted::design
@@ -349,8 +354,8 @@ learner <- R6::R6Class("learner", # nolint
         return(value)
       }
     },
-    # #' Utility to update list of arguments with ellipsis
-    # #' @param args list or NULL
+    #' Utility to update list of arguments with ellipsis
+    #' @param args list or NULL
     update_args = function(args, ...) {
       if (is.null(args)) args <- list() # because predict.args = NULL by default
       dots <- list(...)
@@ -407,7 +412,7 @@ learner_print <- function(self, private) {
     "\nPredict arguments:",
     format_fit_predict_args(private$init$predict.args),
     "\nFormula:",
-    capture.output(print(private$.formula)),
+    capture.output(print(self$formula)),
     "\n"
   )
 

--- a/inst/tinytest/test_cate.R
+++ b/inst/tinytest/test_cate.R
@@ -1,5 +1,11 @@
 library("tinytest")
 
+n <- 1000
+x <- rnorm(n)
+a <- rbinom(n, 1, lava::expit(1 + x))
+y <- 1 + a + x - a * x + rnorm(n)
+d <- data.frame(y = y, a = a, x = x)
+
 true_estimate1 <- function(q1) {
   g <- glm(a ~ x, data = d, family = binomial)
   pi <- predict(g, type = "response")

--- a/inst/tinytest/test_cate.R
+++ b/inst/tinytest/test_cate.R
@@ -1,11 +1,5 @@
 library("tinytest")
 
-n <- 1000
-x <- rnorm(n)
-a <- rbinom(n, 1, lava::expit(1 + x))
-y <- 1 + a + x - a * x + rnorm(n)
-d <- data.frame(y = y, a = a, x = x)
-
 true_estimate1 <- function(q1) {
   g <- glm(a ~ x, data = d, family = binomial)
   pi <- predict(g, type = "response")
@@ -101,3 +95,125 @@ test_cate_deprecated_arguments <- function() {
   )
 }
 test_cate_deprecated_arguments()
+
+
+test_cate_polle <- function() {
+  set.seed(1)
+  n <- 1000
+  x <- rnorm(n)
+  a <- rbinom(n, 1, lava::expit(1 + x))
+  y <- 1 + a + x - a * x + rnorm(n)
+  yb <- rbinom(n, 1, plogis(1 + a + x - a * x))*1.0
+  d <- data.frame(yb = yb, y = y, a = a, x = x)
+
+
+  ## Continuous endpoint
+  a <- cate(response.model = learner_glm(y ~ a*x),
+            propensity.model = a ~ 1, data=d, mc.cores=1)
+
+  pd <- polle::policy_data(data = data.table(d),
+                           action = "a",
+                           covariates = c("x"),
+                           utility = "y")
+  p1 <- polle::policy_def(1)
+  p0 <- polle::policy_def(0)
+  a1 <- polle::policy_eval(policy_data = pd,
+                           policy = p1,
+                           g_models = polle::g_glm( ~ 1),
+                           q_models = polle::q_glm( ~ A*x))
+  a0 <- polle::policy_eval(policy_data = pd,
+                           policy = p0,
+                           g_models = polle::g_glm( ~ 1),
+                           q_models = polle::q_glm( ~ A*x))
+
+  expect_equivalent(coef(a)["E[y(1)]"], coef(a1), tolerance=1e-4)
+  expect_equivalent(coef(a)["E[y(0)]"], coef(a0), tolerance=1e-4)
+  expect_equivalent(vcov(a)["E[y(1)]", "E[y(1)]"],
+                    vcov(a1)[1], tolerance=1e-4)
+  expect_equivalent(vcov(a)["E[y(0)]", "E[y(0)]"],
+                    vcov(a0)[1], tolerance=1e-4)
+
+
+  ## Binary endpoint
+  a <- cate(response.model = learner_glm(yb ~ a*x, family=binomial),
+            propensity.model = a ~ 1, data=d, mc.cores=1)
+
+  pd <- polle::policy_data(data = data.table(d),
+                           action = "a",
+                           covariates = c("x"),
+                           utility = "yb")
+  p1 <- polle::policy_def(1)
+  p0 <- polle::policy_def(0)
+  a1 <- polle::policy_eval(policy_data = pd,
+                           policy = p1,
+                           g_models = polle::g_glm( ~ 1),
+                           q_models = polle::q_glm( ~ A*x, family = binomial()))
+  a0 <- polle::policy_eval(policy_data = pd,
+                           policy = p0,
+                           g_models = polle::g_glm( ~ 1),
+                           q_models = polle::q_glm( ~ A*x, family = binomial()))
+
+  expect_equivalent(coef(a)["E[yb(1)]"], coef(a1), tolerance=1e-3)
+  expect_equivalent(coef(a)["E[yb(0)]"], coef(a0), tolerance=1e-3)
+  expect_equivalent(vcov(a)["E[yb(1)]", "E[yb(1)]"],
+                    vcov(a1)[1], tolerance=1e-3)
+  expect_equivalent(vcov(a)["E[yb(0)]", "E[yb(0)]"],
+                    vcov(a0)[1], tolerance=1e-3)
+
+  ## Binary endpoint, propensity-model with covariate
+  a <- cate(response.model = learner_glm(yb ~ a*x, family=binomial),
+            propensity.model = learner_glm(a ~ x, family=binomial),
+            data=d, mc.cores=1)
+
+  pd <- polle::policy_data(data = data.table(d),
+                           action = "a",
+                           covariates = c("x"),
+                           utility = "yb")
+  p1 <- polle::policy_def(1)
+  p0 <- polle::policy_def(0)
+  a1 <- polle::policy_eval(policy_data = pd,
+                           policy = p1,
+                           g_models = polle::g_glm( ~ x),
+                           q_models = polle::q_glm( ~ A*x, family = binomial()))
+  a0 <- polle::policy_eval(policy_data = pd,
+                           policy = p0,
+                           g_models = polle::g_glm( ~ x),
+                           q_models = polle::q_glm( ~ A*x, family = binomial()))
+
+  expect_equivalent(coef(a)["E[yb(1)]"], coef(a1), tolerance=1e-3)
+  expect_equivalent(coef(a)["E[yb(0)]"], coef(a0), tolerance=1e-3)
+  expect_equivalent(vcov(a)["E[yb(1)]", "E[yb(1)]"],
+                    vcov(a1)[1], tolerance=1e-3)
+  expect_equivalent(vcov(a)["E[yb(0)]", "E[yb(0)]"],
+                    vcov(a0)[1], tolerance=1e-3)
+
+}
+test_cate_polle()
+
+
+test_cate_ate() {
+  set.seed(1)
+  n <- 1000
+  x <- rnorm(n)
+  a <- rbinom(n, 1, lava::expit(1 + x))
+  y <- 1 + a + x - a * x + rnorm(n)
+  yb <- rbinom(n, 1, plogis(1 + a + x - a * x))*1.0
+  d <- data.frame(yb = yb, y = y, a = a, x = x)
+
+  a <- cate(response.model = learner_glm(yb ~ a*x, family=binomial()),
+            propensity.model = learner_glm(a ~ x, family=binomial()),
+            data=d, mc.cores=1)
+
+  at <- ate(yb ~ a, nuisance = ~a*x, propensity = ~x, family=binomial(), data=d)
+
+  expect_equivalent(coef(a)["E[yb(1)]"], coef(at)["a=1"], tolerance=1e-3)
+  expect_equivalent(coef(a)["E[yb(0)]"], coef(at)["a=0"], tolerance=1e-3)
+
+  # not exactly the same standard errors, as the 'ate' function
+  # creates a correction for estimation of both nuisance models
+  expect_equivalent(vcov(a)["E[yb(1)]","E[yb(1)]"],
+                    vcov(at)["a=1","a=1"], tolerance=1e-2)
+  expect_equivalent(vcov(a)["E[yb(0)]","E[yb(0)]"],
+                    vcov(at)["a=0","a=0"], tolerance=1e-2)
+}
+test_cate_ate()

--- a/inst/tinytest/test_cate.R
+++ b/inst/tinytest/test_cate.R
@@ -191,7 +191,7 @@ test_cate_polle <- function() {
 test_cate_polle()
 
 
-test_cate_ate() {
+test_cate_ate <- function() {
   set.seed(1)
   n <- 1000
   x <- rnorm(n)


### PR DESCRIPTION
Hotfix for bug introduced by making `formula` a private member. 
The error occurs when updating the formula with the `update` method. This was not reflected correctly when subsequently calling the `estimate` method.

learner  R6 class: In the `private$fitfun <- function(data, ...)` definition the formula was extracted using a call to `private$.formula`. private is here referencing to the parent-frame environment (class environment) which is not updated 
by the `update`function.