### PR TITLE
feat(learner): change fit active binding to only work as a getter

### DIFF
--- a/R/learner.R
+++ b/R/learner.R
@@ -309,7 +309,7 @@ learner <- R6::R6Class("learner", # nolint
     #' @field clear Remove fitted model from the learner object
     clear = function() invisible(private$fitted <- NULL),
     #' @field fit Return estimated model object.
-    fit = function() return(private$fitted),
+    fit = function() private$fitted,
     #' @field formula Return model formula. Use [learner$update()][learner] to
     #' update the formula.
     formula = function() {

--- a/R/learner.R
+++ b/R/learner.R
@@ -309,10 +309,7 @@ learner <- R6::R6Class("learner", # nolint
     #' @field clear Remove fitted model from the learner object
     clear = function() invisible(private$fitted <- NULL),
     #' @field fit Return estimated model object.
-    fit = function(value) {
-      if (missing(value)) return(private$fitted)
-      else private$fitted <- NULL
-    },
+    fit = function() return(private$fitted),
     #' @field formula Return model formula. Use [learner$update()][learner] to
     #' update the formula.
     formula = function() {


### PR DESCRIPTION
Fixing the current behavior of the active binding;

```
n <- 1e3
x1 <- rnorm(n, sd = 2)
x2 <- rnorm(n)
a <- factor(rbinom(n, 1, 0.5))
y <- x1 + cos(x1) + rnorm(n, sd = 0.5**.5)
d0 <- data.frame(y, x1, x2, a)
lr <- learner_glm(y ~ a + x1 + x2)
lr$estimate(d0)
```

```
r$> lr$fit # use active binding as getter

Call:  stats::glm(formula = formula, family = family, data = data)

Coefficients:
(Intercept)           a1           x1           x2  
   0.117855     0.075752     0.968974     0.004644  

Degrees of Freedom: 999 Total (i.e. Null);  996 Residual
Null Deviance:      4782 
Residual Deviance: 964.7        AIC: 2812
``` 

Now trying to use the active binding as a setter
```
lr$fit <- 2 # use active binding as setter
```
but the actual behavior is to reset the private$fitted attribute
```
r$> lr$fit <- 2 # use active binding as setter

r$> lr$fit
NULL
```

Trying to use the active binding now as a setter will raise an error (which I think is here the correct behavior) 

