### PR TITLE
feat(`cate`): improved behavior when predictions of response and treatment models contain NAs

### DIFF
--- a/R/cate.R
+++ b/R/cate.R
@@ -360,7 +360,6 @@ cate <- function(response.model, # nolint
   folds_out <- if (rep == 1) val$nuisance[[1]]$folds else NULL
   val$p <- lapply(val$nuisance, \(x) Reduce(cbind, x$pval))
   val$q <- lapply(val$nuisance, \(x) Reduce(cbind, x$qval))
-
   val$nuisance <- NULL
 
   res <- list(

--- a/R/cate.R
+++ b/R/cate.R
@@ -360,6 +360,7 @@ cate <- function(response.model, # nolint
   folds_out <- if (rep == 1) val$nuisance[[1]]$folds else NULL
   val$p <- lapply(val$nuisance, \(x) Reduce(cbind, x$pval))
   val$q <- lapply(val$nuisance, \(x) Reduce(cbind, x$qval))
+
   val$nuisance <- NULL
 
   res <- list(
@@ -370,6 +371,23 @@ cate <- function(response.model, # nolint
     data = val # (y, a, p, q)
   )
   class(res) <- c("cate.targeted", "targeted")
+  if (any(mapply(\(x) any(is.na(x)), val$q))) warning(
+    "NAs are present in the predictions of the response.model. Inspect the ",
+    "data$q field of the returned object for more information."
+    # return empty estimate object
+    res$estimate <- lava::estimate(coef = NA, vcov = NULL)
+    return(res)
+  )
+  if (any(mapply(\(x) any(is.na(x)), val$p))) {
+    warning(
+    "NAs are present in the predictions of the treatment.model. Inspect the ",
+    "data$p field of the returned object for more information."
+    )
+    # return object because update method fails when val$p contains NAs and
+    # the error message begin cast does not inform the user about the NAs
+    res$estimate <- lava::estimate(coef = NA, vcov = NULL)
+    return(res)
+  }
   res <- update(res,
                 cate.model = cate.model,
                 data = data,

--- a/R/cate.R
+++ b/R/cate.R
@@ -370,14 +370,15 @@ cate <- function(response.model, # nolint
     data = val # (y, a, p, q)
   )
   class(res) <- c("cate.targeted", "targeted")
-  if (any(mapply(\(x) any(is.na(x)), val$q))) warning(
+  if (any(mapply(\(x) any(is.na(x)), val$q))) {
+    warning(
       "NAs detect in the predictions of the response.model.",
       " Returning a cate object with an blanked estimate field.",
       " Inspect the data$q field of the returned object for more information."
-    # return empty estimate object
+    )
     res$estimate <- lava::estimate(coef = NA, vcov = NULL)
     return(res)
-  )
+  }
   if (any(mapply(\(x) any(is.na(x)), val$p))) {
     warning(
       "NAs detect in the predictions of the treatment.model.",

--- a/R/cate.R
+++ b/R/cate.R
@@ -371,16 +371,18 @@ cate <- function(response.model, # nolint
   )
   class(res) <- c("cate.targeted", "targeted")
   if (any(mapply(\(x) any(is.na(x)), val$q))) warning(
-    "NAs are present in the predictions of the response.model. Inspect the ",
-    "data$q field of the returned object for more information."
+      "NAs detect in the predictions of the response.model.",
+      " Returning a cate object with an blanked estimate field.",
+      " Inspect the data$q field of the returned object for more information."
     # return empty estimate object
     res$estimate <- lava::estimate(coef = NA, vcov = NULL)
     return(res)
   )
   if (any(mapply(\(x) any(is.na(x)), val$p))) {
     warning(
-    "NAs are present in the predictions of the treatment.model. Inspect the ",
-    "data$p field of the returned object for more information."
+      "NAs detect in the predictions of the treatment.model.",
+      " Returning a cate object with an blanked estimate field.",
+      " Inspect the data$q field of the returned object for more information."
     )
     # return object because update method fails when val$p contains NAs and
     # the error message begin cast does not inform the user about the NAs

--- a/inst/tinytest/test_cate.R
+++ b/inst/tinytest/test_cate.R
@@ -255,16 +255,16 @@ test_cate_warning <- function() {
       a ~ 1,
       rep = 2,
       data = dd),
-    pattern = "NAs are present in the predictions of the response.model"
+    pattern = "NAs detect in the predictions of the response.model."
   )
-  
+
   # same for treatment.model
   expect_warning(
     cate(
       response.model = y ~ a,
       treatment.model = a ~ x,
       data = dd),
-    pattern = "NAs are present in the predictions of the treatment.model"
+    pattern = "NAs detect in the predictions of the treatment.model."
   )
 }
 test_cate_warning()

--- a/inst/tinytest/test_cate.R
+++ b/inst/tinytest/test_cate.R
@@ -237,6 +237,35 @@ test_cate_warning <- function() {
     cate(y ~ a * x, A ~ 1, data = d),
     "treatment variable not present"
   )
+
+  # test users are informed about NAs in the q and propensity model
+  dd <- head(d, 50)
+  dd[1, "x"] <- NA
+  expect_warning(
+    cate(
+      response.model = y ~ a * x,
+      a ~ 1,
+      data = dd),
+    pattern = "NAs are present in the predictions of the response.model"
+  )
+  # also works with repetitions
+  expect_warning(
+    cate(
+      response.model = y ~ a * x,
+      a ~ 1,
+      rep = 2,
+      data = dd),
+    pattern = "NAs are present in the predictions of the response.model"
+  )
+  
+  # same for treatment.model
+  expect_warning(
+    cate(
+      response.model = y ~ a,
+      treatment.model = a ~ x,
+      data = dd),
+    pattern = "NAs are present in the predictions of the treatment.model"
+  )
 }
 test_cate_warning()
 

--- a/inst/tinytest/test_cate.R
+++ b/inst/tinytest/test_cate.R
@@ -246,7 +246,7 @@ test_cate_warning <- function() {
       response.model = y ~ a * x,
       a ~ 1,
       data = dd),
-    pattern = "NAs are present in the predictions of the response.model"
+    pattern = "NAs detect in the predictions of the response.model."
   )
   # also works with repetitions
   expect_warning(


### PR DESCRIPTION
The previous behavior were:
`response.model`: fails silently by returning an object where only the `coef` field of the estimate object contains 0. the remaining fields are NAs
`treatment.model`: raises an error in `update.cate.targeted` but does not provide any details about why this happens