### PR TITLE
feat(design): add na.action parameter and preserve formula environment

### DIFF
--- a/R/design.R
+++ b/R/design.R
@@ -234,7 +234,7 @@ design <- function(formula, data, ..., # nolint
   }
 
   if (design.matrix) {
-    x <- model.matrix(mf, data = mf)
+    x <- model.matrix(mf)
     if (!intercept && has_intercept) {
       has_intercept <- FALSE
       x <- x[, -1, drop = FALSE]

--- a/R/design.R
+++ b/R/design.R
@@ -1,4 +1,3 @@
-
 model.extract2 <- function(frame, component) {
   # model.extract version that works with response,offset components
   component <- as.character(substitute(component))
@@ -70,6 +69,8 @@ Specials <- function(formula, spec, split1 = ",", split2 = NULL, ...) {
 #' @param design.matrix (logical) if FALSE then only response and specials are
 #'   returned. Otherwise, the design.matrix `x` is als part of the returned
 #'   object.
+#' @param na.action (function) method to handle missing data
+#'   (default: \code{na.omit})
 #' @return An object of class 'design'
 #' @author Klaus Kähler Holst
 #' @export
@@ -80,7 +81,8 @@ design <- function(formula, data, ..., # nolint
                    specials = NULL,
                    specials.call = NULL,
                    levels = NULL,
-                   design.matrix = TRUE) {
+                   design.matrix = TRUE,
+                   na.action = na.omit) {
   if (inherits(data, c("data.table", "tbl_df"))) {
     data <- as.data.frame(data)
   }
@@ -88,11 +90,13 @@ design <- function(formula, data, ..., # nolint
   if ("subset" %in% names(dots)) stop(
     "subset is not an allowed specials argument for targeted::design"
   )
+  formulaenv <- environment(formula)
   tt <- terms(formula, data = data, specials = specials)
   term.labels <- attr(tt, "term.labels") # predictors
 
   if (response && inherits(
-    try(model.frame(update(tt, ~1), data = data), silent = TRUE),
+    try(model.frame(update(tt, ~1), data = data, na.action = na.action),
+        silent = TRUE),
     "try-error"
   )) { # response appears not to be in `data`
     response <- FALSE
@@ -134,10 +138,12 @@ design <- function(formula, data, ..., # nolint
       }
       fst <- gsub("[\\+]*$", "", fst) # remove potential any trailing '+'
       formula <- as.formula(fst)
+      environment(formula) <- formulaenv
     }
   }
 
   formula0 <- formula
+  environment(formula0) <- formulaenv
   if (!response) formula0 <- formula(delete.response(terms(formula)))
 
   xlev <- levels
@@ -150,11 +156,13 @@ design <- function(formula, data, ..., # nolint
       fs <- reformulate(paste(sterm.list, collapse = " + "))
       fs <- update(formula0, fs)
     }
-    mf <- model.frame(fs, data = data, ...)
+    environment(formula) <- formulaenv
+    mf <- model.frame(fs, data = data, na.action = na.action, ...)
   } else { # also extract design matrix
     mf <- model.frame(tt,
                       data = data, ...,
                       xlev = xlev,
+                      na.action = na.action,
                       drop.unused.levels = FALSE
                       )
     if (is.null(xlev)) {
@@ -209,6 +217,7 @@ design <- function(formula, data, ..., # nolint
         mf <- model.frame(formula0,
                           data = data, ...,
                           xlev = xlev0,
+                          na.action = na.action,
                           drop.unused.levels = FALSE
                           )
       }
@@ -225,7 +234,7 @@ design <- function(formula, data, ..., # nolint
   }
 
   if (design.matrix) {
-    x <- model.matrix(mf, data = data, xlev = xlev0)
+    x <- model.matrix(mf, data = mf)
     if (!intercept && has_intercept) {
       has_intercept <- FALSE
       x <- x[, -1, drop = FALSE]
@@ -250,6 +259,7 @@ design <- function(formula, data, ..., # nolint
       intercept = has_intercept,
       data = data[0, ], ## Empty data.frame to capture structure of data
       specials = specials,
+      na.action = na.action,
       specials.var = specials.var,
       specials.call = specials.call
     ),
@@ -270,6 +280,7 @@ update.design <- function(object, data = NULL, response = FALSE, levels, ...) {
       intercept = object$intercept,
       specials = object$specials,
       specials.call = object$specials.call,
+      na.action = object$na.action,
       response = response
     )
   )

--- a/R/design.R
+++ b/R/design.R
@@ -234,7 +234,7 @@ design <- function(formula, data, ..., # nolint
   }
 
   if (design.matrix) {
-    x <- model.matrix(mf, data=data, xlev=xlev0)
+    x <- model.matrix(mf, data=mf)
     if (!intercept && has_intercept) {
       has_intercept <- FALSE
       x <- x[, -1, drop = FALSE]

--- a/R/design.R
+++ b/R/design.R
@@ -234,7 +234,7 @@ design <- function(formula, data, ..., # nolint
   }
 
   if (design.matrix) {
-    x <- model.matrix(mf)
+    x <- model.matrix(mf, data=data, xlev=xlev0)
     if (!intercept && has_intercept) {
       has_intercept <- FALSE
       x <- x[, -1, drop = FALSE]

--- a/inst/tinytest/test_design.R
+++ b/inst/tinytest/test_design.R
@@ -499,3 +499,86 @@ test_print.design <- function() {
   expect_stdout(print(des), "response \\(length: 10\\)")
 }
 test_print.design()
+
+# test data.table and tibble coercion
+test_design_data_coercion <- function() {
+  # tibble input produces same result as data.frame
+  if (requireNamespace("tibble", quietly = TRUE)) {
+    tbl <- tibble::as_tibble(ddata)
+    dd_tbl <- design(y ~ x1 * x2, tbl)
+    dd_df <- design(y ~ x1 * x2, ddata)
+    expect_equivalent(dd_tbl$x, dd_df$x)
+    expect_equivalent(dd_tbl$y, dd_df$y)
+  }
+
+  # data.table input produces same result as data.frame
+  if (requireNamespace("data.table", quietly = TRUE)) {
+    dt <- data.table::as.data.table(ddata)
+    dd_dt <- design(y ~ x1 * x2, dt)
+    dd_df <- design(y ~ x1 * x2, ddata)
+    expect_equivalent(dd_dt$x, dd_df$x)
+    expect_equivalent(dd_dt$y, dd_df$y)
+  }
+}
+test_design_data_coercion()
+
+# test formula environment preservation
+test_design_formula_env <- function() {
+  # formula referencing a variable from a parent environment
+  make_design <- function() {
+    threshold <- 0
+    f <- y ~ I(x1 > threshold)
+    design(f, ddata)
+  }
+  dd <- make_design()
+  expect_equivalent(dd$y, ddata$y)
+  expect_equivalent(dd$x[, 1], as.numeric(ddata$x1 > 0))
+
+  # specials with formula from parent environment
+  make_design_specials <- function() {
+    f <- y ~ x1 + offset(x2)
+    design(f, ddata, specials = "offset")
+  }
+  dd <- make_design_specials()
+  expect_equivalent(unname(dd$offset), ddata$x2)
+  expect_equivalent(dd$x[, 1], ddata$x1)
+
+  # update also preserves environment correctly
+  dd_upd <- update(dd, head(ddata, 10))
+  expect_equivalent(unname(dd_upd$offset), head(ddata$x2, 10))
+}
+test_design_formula_env()
+
+# test na.action parameter
+test_design_na_action <- function() {
+  ddata_na <- ddata
+  ddata_na[1:3, "x1"] <- NA
+
+  # default na.omit removes rows with NAs
+  dd <- design(y ~ x1, ddata_na)
+  expect_equal(nrow(dd$x), n - 3)
+
+  # na.action is stored in the design object
+  expect_identical(dd$na.action, na.omit)
+
+  # explicit na.omit gives same result as default
+  dd_explicit <- design(y ~ x1, ddata_na, na.action = na.omit)
+  expect_equivalent(dd$x, dd_explicit$x)
+
+  # na.pass keeps all rows including NAs
+  dd_pass <- design(y ~ x1, ddata_na, na.action = na.pass)
+  expect_equal(nrow(dd_pass$x), n)
+  expect_true(all(is.na(dd_pass$x[1:3, ])))
+  expect_identical(dd_pass$na.action, na.pass)
+
+  # na.exclude also removes NA rows from the design matrix
+  dd_excl <- design(y ~ x1, ddata_na, na.action = na.exclude)
+  expect_equal(nrow(dd_excl$x), n - 3)
+  expect_identical(dd_excl$na.action, na.exclude)
+
+  # na.action is forwarded through update
+  dd_upd <- update(dd_pass, ddata_na, response = TRUE)
+  expect_equal(nrow(dd_upd$x), n)
+  expect_identical(dd_upd$na.action, na.pass)
+}
+test_design_na_action()

--- a/inst/tinytest/test_design.R
+++ b/inst/tinytest/test_design.R
@@ -571,11 +571,6 @@ test_design_na_action <- function() {
   expect_true(all(is.na(dd_pass$x[1:3, ])))
   expect_identical(dd_pass$na.action, na.pass)
 
-  # na.exclude also removes NA rows from the design matrix
-  dd_excl <- design(y ~ x1, ddata_na, na.action = na.exclude)
-  expect_equal(nrow(dd_excl$x), n - 3)
-  expect_identical(dd_excl$na.action, na.exclude)
-
   # na.action is forwarded through update
   dd_upd <- update(dd_pass, ddata_na, response = TRUE)
   expect_equal(nrow(dd_upd$x), n)

--- a/man/design.Rd
+++ b/man/design.Rd
@@ -14,7 +14,8 @@ design(
   specials = NULL,
   specials.call = NULL,
   levels = NULL,
-  design.matrix = TRUE
+  design.matrix = TRUE,
+  na.action = na.omit
 )
 }
 \arguments{
@@ -42,6 +43,9 @@ to be assumed for each factor}
 \item{design.matrix}{(logical) if FALSE then only response and specials are
 returned. Otherwise, the design.matrix \code{x} is als part of the returned
 object.}
+
+\item{na.action}{(function) method to handle missing data
+(default: \code{na.omit})}
 }
 \value{
 An object of class 'design'


### PR DESCRIPTION
- Specials declared via `specials` that reference variables not present
  in `data` are silently dropped (their slot in the design object
  becomes NULL) instead of failing in `model.frame`. A design built
  with e.g. `y ~ x + weights(w)` can now be evaluated on data
  without `w`.
- Store the user-provided formula as internal field `formula.original`
  and recurse through it in `update.design`, so dropped specials are
  re-extracted (resurrected) when new data contains their variables
  again. `res$formula` and `res$terms` keep their specials-free
  semantics.
- Factor detection and removal into internal helpers:
  `specials_unavailable()` (variable-based detection via `all.vars`)
  and `remove_terms()` (formula reconstruction via `reformulate`;
  handles offset terms, which `update(f, . ~ . - offset(z))` cannot
  remove). The pre-existing specials-stripping block now reuses
  `remove_terms()`, replacing the string-based gsub rewrite.
- Detection is variable-based only: unrelated formula/data errors
  still surface loudly.