### PR TITLE
feat(design): tolerate specials whose variables are absent from data

### DIFF
--- a/R/design.R
+++ b/R/design.R
@@ -96,7 +96,7 @@ remove_terms <- function(formula, labels, data = NULL) {
 #' @param intercept (logical) If FALSE an intercept is not included in the
 #'   design matrix
 #' @param response (logical) if FALSE the response variable is dropped
-#' @param rm_envir Remove environment
+#' @param rm_envir Remove environment from terms attribute of returned object
 #' @param ... additional arguments (e.g, specials such weights, offsets, ...)
 #' @param specials character vector specifying functions in the formula that
 #'   should be marked as special in the [terms] object
@@ -148,6 +148,18 @@ design <- function(formula, data, ..., # nolint
   }
 
   term.labels <- attr(tt, "term.labels") # predictors
+  sterm.list <- c()
+  if (length(specials) > 0) {
+    des <- attr(tt, "factors")
+    for (s in specials) {
+      sterm <- rownames(des)[attr(tt, "specials")[[s]]]
+      sterm.list <- c(sterm.list, sterm)
+    }
+    # predictors without the specials
+    term.labels <- setdiff(term.labels, unlist(sterm.list))
+    # remove special terms from formula
+    formula <- remove_terms(formula, sterm.list, data = data)
+  }
 
   if (response && inherits(
     try(model.frame(update(tt, ~1), data = data, na.action = na.action),
@@ -156,30 +168,13 @@ design <- function(formula, data, ..., # nolint
   )) { # response appears not to be in `data`
     response <- FALSE
   }
-  # delete response to generate design matrix when making predictions
-  if (!response) {
-    tt <- delete.response(tt)
-  }
-
-  sterm.list <- c()
-  if (length(specials) > 0) {
-    des <- attr(tt, "factors")
-    for (s in specials) {
-      sterm <- rownames(des)[attr(tt, "specials")[[s]]]
-      sterm.list <- c(sterm.list, sterm)
-    }
-    if (length(sterm.list) > 0) {
-      # predictors without the specials
-      term.labels <- setdiff(term.labels, unlist(sterm.list))
-      # remove special terms from formula
-      formula <- remove_terms(formula, sterm.list, data = data)
-    }
-  }
 
   formula0 <- formula
   environment(formula0) <- formulaenv # preserve formula environment
   if (!response) {
     formula0 <- stats::formula(delete.response(terms(formula, data = data)))
+    # delete response to generate design matrix when making predictions
+    tt <- delete.response(tt)
   }
 
   xlev <- levels

--- a/R/design.R
+++ b/R/design.R
@@ -52,6 +52,43 @@ Specials <- function(formula, spec, split1 = ",", split2 = NULL, ...) {
   return(res)
 }
 
+# labels of special terms (e.g. "weights(w)") whose variables are not all
+# present in `data`
+specials_unavailable <- function(terms, data) {
+  pos <- unlist(attr(terms, "specials"))
+  if (length(pos) < 1) return(character(0))
+  labels <- rownames(attr(terms, "factors"))[pos]
+  unavailable <- vapply(labels, function(lab) {
+    vars <- all.vars(str2lang(lab))
+    # skip pathological cases (e.g. `.` inside a special) to avoid false drops
+    length(vars) > 0 && !("." %in% vars) && !all(vars %in% names(data))
+  }, logical(1))
+  return(labels[unavailable])
+}
+
+# remove terms (given by their labels) from a formula. The formula
+# environment is preserved and the right-hand side collapses to `1` when no
+# terms remain. The formula is reconstructed from its terms object, since
+# update(formula, . ~ . - label) cannot remove offset terms, which are
+# carried separately from the regular terms. `data` is only required for
+# formulas containing a `.` on the right-hand side
+remove_terms <- function(formula, labels, data = NULL) {
+  tt <- terms(formula, data = data)
+  vars <- attr(tt, "variables")
+  offset.labels <- vapply(
+    attr(tt, "offset"), function(i) deparse1(vars[[i + 1]]), character(1)
+  )
+  keep <- setdiff(c(attr(tt, "term.labels"), offset.labels), labels)
+  if (length(keep) < 1) keep <- "1"
+  response <- if (attr(tt, "response") == 1) vars[[2]] else NULL
+  f <- reformulate(keep,
+    response = response,
+    intercept = attr(tt, "intercept") == 1
+  )
+  environment(f) <- environment(formula)
+  return(f)
+}
+
 #' Extract design matrix from data.frame and formula
 #' @title Extract design matrix
 #' @param formula formula
@@ -91,7 +128,25 @@ design <- function(formula, data, ..., # nolint
     "subset is not an allowed specials argument for targeted::design"
   )
   formulaenv <- environment(formula)
+
+  # Remember the user's un-stripped formula so future update.design() calls can
+  # re-extract specials if they become available again in new data.
+  # stats::formula() is the identity for formulas and converts a terms object
+  # into its formula (environment preserved in both cases).
+  formula.original <- stats::formula(formula)
+
   tt <- terms(formula, data = data, specials = specials)
+
+  # Drop specials whose variables are not available in `data`. This lets a
+  # design built with e.g. `y ~ x + weights(w)` be (re-)evaluated against data
+  # that lacks `w`: the special is silently omitted (its slot becomes NULL)
+  # instead of failing in the subsequent model.frame() call.
+  unavailable <- specials_unavailable(tt, data)
+  if (length(unavailable) > 0) {
+    formula <- remove_terms(formula, unavailable, data = data)
+    tt <- terms(formula, data = data, specials = specials)
+  }
+
   term.labels <- attr(tt, "term.labels") # predictors
 
   if (response && inherits(
@@ -114,37 +169,18 @@ design <- function(formula, data, ..., # nolint
       sterm.list <- c(sterm.list, sterm)
     }
     if (length(sterm.list) > 0) {
-      # create formula without specials
-      if ((nrow(attr(tt, "factors")) - attr(tt, "response")) ==
-        length(sterm.list)) {
-        # only specials on the rhs, remove everything
-        formula <- update(formula, ~1)
-      } else {
-        # predictors without the specials
-        term.labels <- setdiff(
-          term.labels,
-          unlist(sterm.list)
-        )
-        # formula <- update(tt, reformulate(term.labels))
-      }
-      # remove specials from formula
-      fst <- lava::trim(paste(deparse(formula), collapse = ""), all = TRUE)
-      for (s in sterm.list) {
-        fst <- gsub(
-          lava::trim(s, all = TRUE),
-          "", fst,
-          fixed = TRUE
-        )
-      }
-      fst <- gsub("[\\+]*$", "", fst) # remove potential any trailing '+'
-      formula <- as.formula(fst)
-      environment(formula) <- formulaenv
+      # predictors without the specials
+      term.labels <- setdiff(term.labels, unlist(sterm.list))
+      # remove special terms from formula
+      formula <- remove_terms(formula, sterm.list, data = data)
     }
   }
 
   formula0 <- formula
-  environment(formula0) <- formulaenv
-  if (!response) formula0 <- formula(delete.response(terms(formula)))
+  environment(formula0) <- formulaenv # preserve formula environment
+  if (!response) {
+    formula0 <- stats::formula(delete.response(terms(formula, data = data)))
+  }
 
   xlev <- levels
   xlev[["response_"]] <- NULL
@@ -251,6 +287,7 @@ design <- function(formula, data, ..., # nolint
   res <- c(
     list(
       formula = formula, # formula without specials
+      formula.original = formula.original, # user-provided formula (internal)
       terms = tt,
       term.labels = term.labels,
       levels = xlev,
@@ -273,7 +310,7 @@ update.design <- function(object, data = NULL, response = FALSE, levels, ...) {
   if (is.null(data)) data <- object$data
   if (missing(levels)) levels <- object$levels
   return(
-    design(object$terms,
+    design(object$formula.original,
       data = data,
       design.matrix = object$design.matrix,
       levels = levels,

--- a/inst/tinytest/test_design.R
+++ b/inst/tinytest/test_design.R
@@ -583,20 +583,29 @@ test_design_specials_missing_var <- function() {
   d1 <- ddata
   d1$w <- runif(n)
   # baseline: variable present -> special populated
-  dd <- design(y ~ x1 + weights(w), d1, specials = "weights")
+  f_orig <- "y ~ x1 + weights(w)"
+  dd <- design(formula(f_orig), d1, specials = "weights")
   expect_equal(unname(dd$weights), d1$w)
   expect_equal(colnames(dd$x), "x1")
 
   # update with data lacking `w` -> weights slot becomes NULL, x still correct
   d2 <- ddata # no `w`
   dd_upd <- update(dd, d2, response = TRUE)
-  expect_true(is.null(dd_upd$weights))
+  expect_true(
+    is.null(dd_upd$weights) &&
+    "weights" %in% names(dd_upd) && # slot exists
+    "weights" %in% dd_upd$specials # special variable still exist
+  )
   expect_equal(colnames(dd_upd$x), "x1")
   expect_equivalent(dd_upd$x[, "x1"], d2$x1)
 
   # construction against data missing the special's variable also tolerated
   dd2 <- design(y ~ x1 + weights(w), d2, specials = "weights")
-  expect_true(is.null(dd2$weights))
+  expect_true(
+     is.null(dd2$weights) &&
+    "weights" %in% names(dd2) &&
+    "weights" %in% dd2$specials
+  )
   expect_equal(colnames(dd2$x), "x1")
 
   # two specials, only one droppable
@@ -639,13 +648,13 @@ test_design_specials_missing_var <- function() {
   expect_equal(unname(dd2_res$weights), d1$w)
 
   # the original formula (incl. specials) is preserved across evaluations
-  f_orig <- "y ~ x1 + weights(w)"
   expect_equal(deparse(dd$formula.original), f_orig)
   expect_equal(deparse(dd_upd$formula.original), f_orig)
   expect_equal(deparse(dd_res$formula.original), f_orig)
   # while `formula` remains the specials-free formula
-  expect_equal(deparse(dd$formula), "y ~ x1")
-  expect_equal(deparse(dd_upd$formula), "y ~ x1")
+  f_orig_wo_weights <- trimws(strsplit(f_orig, "\\+")[[1]][1])
+  expect_equal(deparse(dd$formula), f_orig_wo_weights)
+  expect_equal(deparse(dd_upd$formula), f_orig_wo_weights)
 
   # two specials: dropped and restored through a round-trip
   dd3_res <- update(dd3b, d3, response = TRUE)

--- a/inst/tinytest/test_design.R
+++ b/inst/tinytest/test_design.R
@@ -577,3 +577,124 @@ test_design_na_action <- function() {
   expect_identical(dd_upd$na.action, na.pass)
 }
 test_design_na_action()
+
+# test tolerance of specials whose variables are absent from `data`
+test_design_specials_missing_var <- function() {
+  d1 <- ddata
+  d1$w <- runif(n)
+  # baseline: variable present -> special populated
+  dd <- design(y ~ x1 + weights(w), d1, specials = "weights")
+  expect_equal(unname(dd$weights), d1$w)
+  expect_equal(colnames(dd$x), "x1")
+
+  # update with data lacking `w` -> weights slot becomes NULL, x still correct
+  d2 <- ddata # no `w`
+  dd_upd <- update(dd, d2, response = TRUE)
+  expect_true(is.null(dd_upd$weights))
+  expect_equal(colnames(dd_upd$x), "x1")
+  expect_equivalent(dd_upd$x[, "x1"], d2$x1)
+
+  # construction against data missing the special's variable also tolerated
+  dd2 <- design(y ~ x1 + weights(w), d2, specials = "weights")
+  expect_true(is.null(dd2$weights))
+  expect_equal(colnames(dd2$x), "x1")
+
+  # two specials, only one droppable
+  d3 <- d1  # has x1, x2, w
+  dd3 <- design(y ~ x1 + offset(x2) + weights(w), d3,
+                specials = c("offset", "weights"))
+  expect_equivalent(unname(dd3$offset), d3$x2)
+  expect_equivalent(unname(dd3$weights), d3$w)
+  # drop only weights on update
+  d3b <- d3[, c("y", "x1", "x2")]
+  dd3b <- update(dd3, d3b, response = TRUE)
+  expect_true(is.null(dd3b$weights))
+  expect_equivalent(unname(dd3b$offset), d3b$x2)
+  expect_equal(colnames(dd3b$x), "x1")
+
+  # entire RHS is a droppable special -> zero-column design matrix
+  dd4 <- design(y ~ weights(w), d2, specials = "weights")
+  expect_true(is.null(dd4$weights))
+  expect_equal(ncol(dd4$x), 0)
+
+  # multi-arg special: any missing variable drops the whole special
+  dd5 <- design(y ~ x1 + stratify(x2, w), d2, specials = "stratify")
+  expect_true(is.null(dd5$stratify))
+  expect_equal(colnames(dd5$x), "x1")
+
+  # print() should not list a dropped special under "specials"
+  expect_stdout(print(dd_upd), "design matrix")
+  # (specifically: 'weights' should not appear in the specials section)
+  out <- capture.output(print(dd_upd))
+  expect_false(any(grepl("^ - weights", out)))
+
+  # dropped specials are resurrected when updating with data that contains
+  # the variable again
+  dd_res <- update(dd_upd, d1, response = TRUE)
+  expect_equal(unname(dd_res$weights), d1$w)
+  expect_equal(colnames(dd_res$x), "x1")
+
+  # also when the design was constructed against data missing the variable
+  dd2_res <- update(dd2, d1, response = TRUE)
+  expect_equal(unname(dd2_res$weights), d1$w)
+
+  # the original formula (incl. specials) is preserved across evaluations
+  f_orig <- "y ~ x1 + weights(w)"
+  expect_equal(deparse(dd$formula.original), f_orig)
+  expect_equal(deparse(dd_upd$formula.original), f_orig)
+  expect_equal(deparse(dd_res$formula.original), f_orig)
+  # while `formula` remains the specials-free formula
+  expect_equal(deparse(dd$formula), "y ~ x1")
+  expect_equal(deparse(dd_upd$formula), "y ~ x1")
+
+  # two specials: dropped and restored through a round-trip
+  dd3_res <- update(dd3b, d3, response = TRUE)
+  expect_equivalent(unname(dd3_res$offset), d3$x2)
+  expect_equivalent(unname(dd3_res$weights), d3$w)
+}
+test_design_specials_missing_var()
+
+# unit tests for the internal helpers
+test_design_internal_helpers <- function() {
+  remove_terms <- targeted:::remove_terms
+  specials_unavailable <- targeted:::specials_unavailable
+
+  # remove a single term
+  expect_equal(deparse(remove_terms(y ~ x + weights(w), "weights(w)")),
+               "y ~ x")
+  # removing the only term collapses the rhs to an intercept
+  expect_equal(deparse(remove_terms(y ~ weights(w), "weights(w)")), "y ~ 1")
+  # explicitly removed intercept is preserved
+  expect_equal(deparse(remove_terms(y ~ -1 + x + weights(w), "weights(w)")),
+               "y ~ x - 1")
+  # multiple labels
+  expect_equal(
+    deparse(remove_terms(y ~ x + offset(z) + weights(w),
+                         c("offset(z)", "weights(w)"))),
+    "y ~ x"
+  )
+  # formula environment is preserved
+  e <- new.env()
+  f <- y ~ x + weights(w)
+  environment(f) <- e
+  expect_identical(environment(remove_terms(f, "weights(w)")), e)
+  # `.` on the rhs is expanded from data before removal
+  d <- data.frame(y = 1, x = 1, w = 1)
+  expect_equal(deparse(remove_terms(y ~ . - w + weights(w), "weights(w)",
+                                    data = d)),
+               "y ~ x")
+
+  # specials_unavailable: reports special terms with missing variables
+  tt <- terms(y ~ x + weights(w) + offset(z),
+              specials = c("weights", "offset"))
+  expect_equal(specials_unavailable(tt, data.frame(y = 1, x = 1)),
+               c("weights(w)", "offset(z)"))
+  expect_equal(specials_unavailable(tt, data.frame(y = 1, x = 1, w = 1)),
+               "offset(z)")
+  expect_equal(length(specials_unavailable(tt, data.frame(x = 1, w = 1, z = 1))),
+               0)
+  # no specials declared -> nothing to report
+  tt0 <- terms(y ~ x)
+  expect_equal(length(specials_unavailable(tt0, data.frame(x = 1))), 0)
+}
+test_design_internal_helpers()

--- a/man/design.Rd
+++ b/man/design.Rd
@@ -30,7 +30,7 @@ design matrix}
 
 \item{response}{(logical) if FALSE the response variable is dropped}
 
-\item{rm_envir}{Remove environment}
+\item{rm_envir}{Remove environment from terms attribute of returned object}
 
 \item{specials}{character vector specifying functions in the formula that
 should be marked as special in the \link{terms} object}


### PR DESCRIPTION
- Specials declared via `specials` that reference variables not present
  in `data` are silently dropped (their slot in the design object
  becomes NULL) instead of failing in `model.frame`. A design built
  with e.g. `y ~ x + weights(w)` can now be evaluated on data
  without `w`.
- Store the user-provided formula as internal field `formula.original`
  and recurse through it in `update.design`, so dropped specials are
  re-extracted (resurrected) when new data contains their variables
  again. `res$formula` and `res$terms` keep their specials-free
  semantics.
- Factor detection and removal into internal helpers:
  `specials_unavailable()` (variable-based detection via `all.vars`)
  and `remove_terms()` (formula reconstruction via `reformulate`;
  handles offset terms, which `update(f, . ~ . - offset(z))` cannot
  remove). The pre-existing specials-stripping block now reuses
  `remove_terms()`, replacing the string-based gsub rewrite.
- Detection is variable-based only: unrelated formula/data errors
  still surface loudly.